### PR TITLE
catch packages Init error

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -61,6 +61,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func init() {
+	if KubeConfigPath() == "" {
+		fmt.Fprintf(os.Stderr, "Please set KUBECONFIG first!\n")
+		os.Exit(0)
+	}
+}
+
 // WaitForInternalRegistryHostname waits for the internal registry hostname to be made available to the cluster.
 func WaitForInternalRegistryHostname(oc *CLI) (string, error) {
 	e2e.Logf("Waiting up to 2 minutes for the internal registry hostname to be published")


### PR DESCRIPTION
We get the below errors if don't set the `KUBECONFIG`. It's noisy and the beginners cannot find the root cause immediately. It's better if we can throw the exact error.
```console
mac:extended-platform-tests jianzhang$ echo $KUBECONFIG

mac:extended-platform-tests jianzhang$ ./extended-platform-tests 
goroutine 1 [running, locked to thread]:
runtime/debug.Stack(0x6d, 0xc001edd200, 0x5ae)
	/usr/local/Cellar/go/1.13.1/libexec/src/runtime/debug/stack.go:24 +0x9d
github.com/openshift/openshift-tests/test/extended/util.FatalErr(0x564f8e0, 0xc00245a780)
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/util/client.go:643 +0x26
github.com/openshift/openshift-tests/test/extended/util.(*CLI).AdminConfig(0xc0052fd800, 0xa)
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/util/client.go:443 +0x65
github.com/openshift/openshift-tests/test/extended/cli.glob..func4()
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/cli/explain.go:332 +0x9e
github.com/onsi/ginkgo/internal/suite.(*Suite).PushContainerNode(0xc0002bd0e0, 0x5f0e9aa, 0x10, 0x61a60e8, 0x0, 0x937cf76, 0x68, 0x148, 0xc000b27b00, 0x218)
	/Users/jianzhang/goproject/pkg/mod/github.com/openshift/onsi-ginkgo@v1.4.1-0.20190902091932-d0603c19fe78/internal/suite/suite.go:144 +0x158
github.com/onsi/ginkgo.Describe(0x5f0e9aa, 0x10, 0x61a60e8, 0xc00016e601)
	/Users/jianzhang/goproject/pkg/mod/github.com/openshift/onsi-ginkgo@v1.4.1-0.20190902091932-d0603c19fe78/ginkgo_dsl.go:293 +0xaa
github.com/openshift/openshift-tests/test/extended/cli.init()
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/cli/explain.go:328 +0xb5

Jan 27 15:51:51.986: FAIL: open : no such file or directory

Full Stack Trace
github.com/openshift/openshift-tests/test/extended/util.FatalErr(0x564f8e0, 0xc00245a780)
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/util/client.go:644 +0x118
github.com/openshift/openshift-tests/test/extended/util.(*CLI).AdminConfig(0xc0052fd800, 0xa)
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/util/client.go:443 +0x65
github.com/openshift/openshift-tests/test/extended/cli.glob..func4()
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/cli/explain.go:332 +0x9e
github.com/onsi/ginkgo/internal/suite.(*Suite).PushContainerNode(0xc0002bd0e0, 0x5f0e9aa, 0x10, 0x61a60e8, 0x0, 0x937cf76, 0x68, 0x148, 0xc000b27b00, 0x218)
	/Users/jianzhang/goproject/pkg/mod/github.com/openshift/onsi-ginkgo@v1.4.1-0.20190902091932-d0603c19fe78/internal/suite/suite.go:144 +0x158
github.com/onsi/ginkgo.Describe(0x5f0e9aa, 0x10, 0x61a60e8, 0xc00016e601)
	/Users/jianzhang/goproject/pkg/mod/github.com/openshift/onsi-ginkgo@v1.4.1-0.20190902091932-d0603c19fe78/ginkgo_dsl.go:293 +0xaa
github.com/openshift/openshift-tests/test/extended/cli.init()
	/Users/jianzhang/goproject/src/github.com/openshift/extended-platform-tests/test/extended/cli/explain.go:328 +0xb5
OpenShift Extended Platform Tests

 This command verifies behavior of an OpenShift cluster by running remote tests against the cluster API that exercise functionality. In general these tests may be disruptive or require elevated privileges - see the descriptions of each test suite.

Usage:
   [command]

Available Commands:
  help        Help about any command
  run         Run a test suite
  run-monitor Continuously verify the cluster is functional
  run-test    Run a single test by name
  run-upgrade Run an upgrade suite

Flags:
  -h, --help   help for this command

Use " [command] --help" for more information about a command.
``` 
I'd like to catch the error when importing a module. I'm not sure if this's a good solution. Any comments are welcome! After this PR, it works like:
```console
mac:extended-platform-tests jianzhang$ echo $KUBECONFIG

mac:extended-platform-tests jianzhang$ ./extended-platform-tests 
Please set KUBECONFIG first!
mac:extended-platform-tests jianzhang$ export KUBECONFIG=/Users/jianzhang/44-kubeconfig
mac:extended-platform-tests jianzhang$ ./extended-platform-tests 
OpenShift Extended Platform Tests

 This command verifies behavior of an OpenShift cluster by running remote tests against the cluster API that exercise functionality. In general these tests may be disruptive or require elevated privileges - see the descriptions of each test suite.

Usage:
   [command]

Available Commands:
  help        Help about any command
  run         Run a test suite
  run-monitor Continuously verify the cluster is functional
  run-test    Run a single test by name
  run-upgrade Run an upgrade suite

Flags:
  -h, --help   help for this command

Use " [command] --help" for more information about a command.
```