### PR TITLE
update test case OCP-21126

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,5 @@ test-e2e: test-unit
 .PHONY: test-e2e
 
 clean:
-	$(RM) ./extended-platform-tests
+	$(RM) ./cmd/extended-platform-tests/extended-platform-tests
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to compile the `openshift-tests` binary, please see the [origin](htt
 $ mkdir -p ${GOPATH}/src/github.com/openshift/
 $ cd ${GOPATH}/src/github.com/openshift/
 $ git clone git@github.com:openshift/openshift-tests.git
-$ make WHAT=cmd/extended-platform-tests  
+$ cd cmd/extended-platform-tests/ && go build 
 ```
 
 Run `./extended-platform-tests --help` to get started.
@@ -86,6 +86,15 @@ $ ./extended-platform-tests run all --dry-run|grep "\[Serial\] olm version shoul
 
 ```console
 $ ./extended-platform-tests run openshift/conformance/serial --run "\[Serial\] olm version should contain the source commit id"
+```
+
+## How to generate bindata
+If you have some new YAML files used in your code, you have to generate the bindata first.
+Run `make update` to update the bindata. For example, you can see the bindata has been updated after running the `make update`. As follows: 
+```console
+$ git status
+	modified:   test/extended/testdata/bindata.go
+	new file:   test/extended/testdata/olm/etcd-subscription-manual.yaml
 ```
 
 ## Run ISV Operators test

--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -164,6 +164,7 @@ var _ = g.Describe("[Feature:Platform] an end user use OLM", func() {
 		operatorGroup       = filepath.Join(buildPruningBaseDir, "operatorgroup.yaml")
 		etcdSub             = filepath.Join(buildPruningBaseDir, "etcd-subscription.yaml")
 		etcdCluster         = filepath.Join(buildPruningBaseDir, "etcd-cluster.yaml")
+		etcdSubManual       = filepath.Join(buildPruningBaseDir, "etcd-subscription-manual.yaml")
 	)
 
 	files := []string{operatorGroup, etcdSub}
@@ -301,6 +302,45 @@ var _ = g.Describe("[Feature:Platform] an end user use OLM", func() {
 		o.Expect(amountOfContainers).To(o.Equal(amountOfContainersWithFallbackToLogsOnError))
 		if amountOfContainers != amountOfContainersWithFallbackToLogsOnError {
 			e2e.Failf("OLM does not have all containers definied with FallbackToLogsOnError terminationMessagePolicy")
+		}
+	})
+
+	// author: scolange@redhat.com
+	g.It("OLM-Medium-OCP-21126-Subscription status says CSV is installed", func() {
+		e2e.Logf(oc.Namespace())
+		e2e.Logf(fmt.Sprintf(oc.Namespace()))
+		e2e.Logf(fmt.Sprintf("NAMESPACE=%s", oc.Namespace()))
+
+		configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", etcdSubManual, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), "INSTALLPLAN=Manual", "SOURCENAME=community-operators", "SOURCENAMESPACE=openshift-marketplace").OutputToFile("config.json")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		inst, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", "-n", oc.Namespace(), "-o", "jsonpath={.items[*].spec.installPlanApproval}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(inst).To(o.Equal("Manual"))
+		if inst == "Manual" {
+			e2e.Logf("Install Approval Manual")
+		} else {
+			e2e.Failf("No packages for evaluating if package namespace is not NULL")
+		}
+
+		instCsv, err1 := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", "-n", oc.Namespace(), "-o", "jsonpath={.items[*].status.installedCSV}").Output()
+		o.Expect(err1).NotTo(o.HaveOccurred())
+		o.Expect(instCsv).To(o.Equal(""))
+		if instCsv == "" {
+			e2e.Logf("NO CSV Inside subscription")
+		} else {
+			e2e.Failf("No packages for evaluating if package namespace is not NULL")
+		}
+
+		msgcsv, err2 := oc.AsAdmin().WithoutNamespace().Run("get").Args("csv", "-n", oc.Namespace()).Output()
+		o.Expect(err2).NotTo(o.HaveOccurred())
+		o.Expect(msgcsv).To(o.ContainSubstring("No resources found"))
+		if strings.Contains(msgcsv, "No resources found") {
+			e2e.Logf("NO CSV Installed")
+		} else {
+			e2e.Failf("No packages for evaluating if package namespace is not NULL")
 		}
 	})
 

--- a/test/extended/testdata/olm/etcd-subscription-manual.yaml
+++ b/test/extended/testdata/olm/etcd-subscription-manual.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    channel: singlenamespace-alpha
+    installPlanApproval: "${INSTALLPLAN}"
+    name: etcd
+    source: "${SOURCENAME}"
+    sourceNamespace: "${SOURCENAMESPACE}"
+    startingCSV: etcdoperator.v0.9.4
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: INSTALLPLAN
+- name: SOURCENAME
+- name: SOURCENAMESPACE


### PR DESCRIPTION
Clone https://github.com/openshift/origin/pull/24818 from origin, do some modifications. cc: @scolange 
```console
mac:extended-platform-tests jianzhang$ ./extended-platform-tests run all --dry-run |grep "Subscription status says CSV is installed" |./extended-platform-tests run -f -

Apr 14 16:19:55.172: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get packagemanifest -l catalog=certified-operators -o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\n'}{end}'
Apr 14 16:20:08.133: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get packagemanifest -l catalog=redhat-operators -o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\n'}{end}'
Apr 14 16:20:09.603: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get packagemanifest -l catalog=community-operators -o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\n'}{end}'
I0414 16:20:20.064430   20485 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0414 16:20:34.630776   20487 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[Feature:Platform] an end user use OLM OLM-Medium-OCP-21126-Subscription status says CSV is installed [Suite:openshift/conformance/parallel]"

E0414 16:20:41.666099   20487 request.go:929] Unexpected error when reading response body: net/http: request canceled (Client.Timeout exceeded while reading body)
I0414 16:21:07.474222   20487 trace.go:116] Trace[814403964]: "Reflector ListAndWatch" name:pkg/mod/github.com/openshift/kubernetes-client-go@v0.0.0-20200106170045-1fda2942f64d/tools/cache/reflector.go:105 (started: 2020-04-14 16:20:34.660084 +0800 CST m=+40.844372581) (total time: 32.813899654s):
Trace[814403964]: [32.81366812s] [32.81366812s] Objects listed
Apr 14 16:20:35.929: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get packagemanifest -l catalog=certified-operators -o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\n'}{end}'
Apr 14 16:20:40.118: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get packagemanifest -l catalog=redhat-operators -o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\n'}{end}'
Apr 14 16:20:41.711: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get packagemanifest -l catalog=community-operators -o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\n'}{end}'
I0414 16:20:54.140659   20504 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Apr 14 16:20:54.170: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Apr 14 16:21:00.551: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Apr 14 16:21:01.520: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Apr 14 16:21:01.520: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Apr 14 16:21:01.520: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Apr 14 16:21:02.726: INFO: e2e test version: v0.0.0-master+$Format:%h$
Apr 14 16:21:04.067: INFO: kube-apiserver version: v1.16.2
Apr 14 16:21:04.456: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [Feature:Platform] an end user use OLM
  /Users/jianzhang/goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [Feature:Platform] an end user use OLM
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:109
Apr 14 16:21:09.268: INFO: configPath is now "/var/folders/2c/4whhm34n7892mf9l2j02cf480000gn/T/configfile956522914"
Apr 14 16:21:09.268: INFO: The user is now "e2e-test-olm-23440-2vn8d-user"
Apr 14 16:21:09.268: INFO: Creating project "e2e-test-olm-23440-2vn8d"
Apr 14 16:21:09.777: INFO: Waiting on permissions in project "e2e-test-olm-23440-2vn8d" ...
Apr 14 16:21:10.354: INFO: Waiting for ServiceAccount "default" to be provisioned...
Apr 14 16:21:11.154: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Apr 14 16:21:12.777: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Apr 14 16:21:13.135: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Apr 14 16:21:14.137: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Apr 14 16:21:14.667: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Apr 14 16:21:15.993: INFO: Project "e2e-test-olm-23440-2vn8d" has been fully provisioned.
[It] OLM-Medium-OCP-21126-Subscription status says CSV is installed [Suite:openshift/conformance/parallel]
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:309
Apr 14 16:21:15.993: INFO: e2e-test-olm-23440-2vn8d
Apr 14 16:21:15.993: INFO: e2e-test-olm-23440-2vn8d
Apr 14 16:21:15.993: INFO: NAMESPACE=e2e-test-olm-23440-2vn8d
Apr 14 16:21:15.994: INFO: Running 'oc --namespace=e2e-test-olm-23440-2vn8d --kubeconfig=/Users/jianzhang/upgrade-kubeconfig process --ignore-unknown-parameters=true -f /var/folders/2c/4whhm34n7892mf9l2j02cf480000gn/T/fixture-testdata-dir292527503/test/extended/testdata/olm/etcd-subscription-manual.yaml -p NAME=test-operator NAMESPACE=e2e-test-olm-23440-2vn8d INSTALLPLAN=Manual SOURCENAME=community-operators SOURCENAMESPACE=openshift-marketplace'
Apr 14 16:21:19.179: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig create -f /tmp/e2e-test-olm-23440-2vn8d-config.json'
subscription.operators.coreos.com/test-operator created
Apr 14 16:21:21.995: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get sub -n e2e-test-olm-23440-2vn8d -o jsonpath={.items[*].spec.installPlanApproval}'
Apr 14 16:21:24.250: INFO: Install Approval Manual
Apr 14 16:21:24.250: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get sub -n e2e-test-olm-23440-2vn8d -o jsonpath={.items[*].status.installedCSV}'
Apr 14 16:21:28.270: INFO: NO CSV Inside subscription
Apr 14 16:21:28.271: INFO: Running 'oc --kubeconfig=/Users/jianzhang/upgrade-kubeconfig get csv -n e2e-test-olm-23440-2vn8d'
Apr 14 16:21:32.211: INFO: NO CSV Installed
[AfterEach] [Feature:Platform] an end user use OLM
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:101
Apr 14 16:21:32.789: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-23440-2vn8d-user}, err: <nil>
Apr 14 16:21:33.662: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-23440-2vn8d}, err: <nil>
Apr 14 16:21:35.105: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  3jKRSFliRPGJjcZbyZKyfwAAAAAAAAAA}, err: <nil>
[AfterEach] [Feature:Platform] an end user use OLM
  /Users/jianzhang/goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Apr 14 16:21:35.106: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-23440-2vn8d" for this suite.
Apr 14 16:21:39.952: INFO: Running AfterSuite actions on all nodes
Apr 14 16:21:39.952: INFO: Running AfterSuite actions on node 1

passed: (1m5s) 2020-04-14T08:21:39 "[Feature:Platform] an end user use OLM OLM-Medium-OCP-21126-Subscription status says CSV is installed [Suite:openshift/conformance/parallel]"


Timeline:

Apr 14 08:20:38.665 I openshift-apiserver OpenShift API started failing: Get https://api.zhsunupgrade.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s: context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Apr 14 08:20:38.665 E kube-apiserver Kube API started failing: Get https://api.zhsunupgrade.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Apr 14 08:20:49.663 - 14s   E kube-apiserver Kube API is not responding to GET requests
Apr 14 08:20:49.663 - 14s   E openshift-apiserver OpenShift API is not responding to GET requests
Apr 14 08:21:07.787 I openshift-apiserver OpenShift API started responding to GET requests
Apr 14 08:21:07.788 I kube-apiserver Kube API started responding to GET requests

1 pass, 0 skip (1m5s)
```