### PR TITLE
Remove the noise output from the `--help`

### DIFF
--- a/test/extended/isv/isv.go
+++ b/test/extended/isv/isv.go
@@ -34,11 +34,11 @@ var _ = g.Describe("[Suite:openshift/isv] Operator", func() {
 	var (
 		oc                      = exutil.NewCLI("isv", exutil.KubeConfigPath())
 		catalogLabels           = []string{"certified-operators", "redhat-operators", "community-operators"}
-		output, _               = oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[0], "-o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\\n'}{end}").Output()
+		output, _               = oc.AsAdmin().WithoutNamespace().NotShowInfo().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[0], "-o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\\n'}{end}").Output()
 		certifiedPackages       = strings.Split(output, "\n")
-		output2, _              = oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[1], "-o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\\n'}{end}").Output()
+		output2, _              = oc.AsAdmin().WithoutNamespace().NotShowInfo().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[1], "-o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\\n'}{end}").Output()
 		redhatOperatorsPackages = strings.Split(output2, "\n")
-		output3, _              = oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[2], "-o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\\n'}{end}").Output()
+		output3, _              = oc.AsAdmin().WithoutNamespace().NotShowInfo().Run("get").Args("packagemanifest", "-l catalog="+catalogLabels[2], "-o=jsonpath={range .items[*]}{.metadata.labels.catalog}:{.metadata.name}{'\\n'}{end}").Output()
 		communityPackages       = strings.Split(output3, "\n")
 		packages1               = append(certifiedPackages, redhatOperatorsPackages...)
 		allPackages             = append(packages1, communityPackages...)

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -79,6 +79,7 @@ type CLI struct {
 	stdout             io.Writer
 	stderr             io.Writer
 	verbose            bool
+	showInfo           bool
 	withoutNamespace   bool
 	kubeFramework      *e2e.Framework
 
@@ -104,6 +105,7 @@ func NewCLI(project, adminConfigPath string) *CLI {
 	client.kubeFramework.SkipNamespaceCreation = true
 	client.username = "admin"
 	client.execPath = "oc"
+	client.showInfo = true
 	client.adminConfigPath = adminConfigPath
 
 	g.BeforeEach(client.SetupProject)
@@ -124,7 +126,7 @@ func NewCLIWithoutNamespace(project string) *CLI {
 	client.username = "admin"
 	client.execPath = "oc"
 	client.adminConfigPath = KubeConfigPath()
-
+	client.showInfo = true
 	return client
 }
 
@@ -178,6 +180,12 @@ func (c *CLI) SetNamespace(ns string) *CLI {
 			Name: ns,
 		},
 	}
+	return c
+}
+
+// WithoutNamespace instructs the command should be invoked without adding --namespace parameter
+func (c *CLI) NotShowInfo() *CLI {
+	c.showInfo = true
 	return c
 }
 
@@ -525,7 +533,9 @@ func (c *CLI) Output() (string, error) {
 	}
 	cmd := exec.Command(c.execPath, c.finalArgs...)
 	cmd.Stdin = c.stdin
-	e2e.Logf("Running '%s %s'", c.execPath, strings.Join(c.finalArgs, " "))
+	if c.showInfo {
+		e2e.Logf("Running '%s %s'", c.execPath, strings.Join(c.finalArgs, " "))
+	}
 	out, err := cmd.CombinedOutput()
 	trimmed := strings.TrimSpace(string(out))
 	switch err.(type) {


### PR DESCRIPTION
FIx for issue https://github.com/openshift/openshift-tests/issues/26

./extended-platform-tests --help
```
OpenShift Extended Platform Tests

 This command verifies behavior of an OpenShift cluster by running remote tests against the cluster API that exercise functionality. In general these tests may be disruptive or require elevated privileges - see the descriptions of each test suite.

Usage:
   [command]

Available Commands:
  help        Help about any command
  run         Run a test suite
  run-monitor Continuously verify the cluster is functional
  run-test    Run a single test by name
  run-upgrade Run an upgrade suite

Flags:
  -h, --help   help for this command

Use " [command] --help" for more information about a command.
```
