### PR TITLE
enhance OCP-25679 and OCP-24870 to apply 4.5

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -258,11 +258,13 @@ var _ = g.Describe("[sig-operators] an end user handle OLM within a namespace", 
 		sub.namespace = oc.Namespace()
 
 		g.By("Create csv with failure because of no operator group")
-		sub.create(oc, itName, dr)
-		newCheck("expect", asUser, withNamespace, compare, "Failed"+"NoOperatorGroup", ok, []string{"csv", sub.installedCSV, "-o=jsonpath={.status.phase}{.status.reason}"}).check(oc)
+		sub.createWithoutCheck(oc, itName, dr)
+		newCheck("present", asUser, withNamespace, notPresent, "", ok, []string{"csv", sub.currentCSV}).check(oc)
+		sub.delete(itName, dr)
 
 		g.By("Create opertor group and then csv is created with success")
 		og.create(oc, itName, dr)
+		sub.create(oc, itName, dr)
 		newCheck("expect", asUser, withNamespace, compare, "Succeeded"+"InstallSucceeded", ok, []string{"csv", sub.installedCSV, "-o=jsonpath={.status.phase}{.status.reason}"}).check(oc)
 	})
 
@@ -473,23 +475,23 @@ var _ = g.Describe("[sig-operators] an end user handle OLM within all namespace"
 		var (
 			itName = g.CurrentGinkgoTestDescription().TestText
 			sub    = subscriptionDescription{
-				name:                   "knative-eventing-operator",
+				name:                   "teiid",
 				namespace:              "openshift-operators",
-				channel:                "alpha",
+				channel:                "beta",
 				ipApproval:             "Automatic",
-				operator:               "knative-eventing-operator",
+				operator:               "teiid",
 				catalogSourceName:      "community-operators",
 				catalogSourceNamespace: "openshift-marketplace",
-				// startingCSV:            "knative-eventing-operator.v0.12.0",
+				// startingCSV:            "teiid.v0.3.0",
 				startingCSV:     "", //get it from package based on currentCSV if ipApproval is Automatic
 				currentCSV:      "",
 				installedCSV:    "",
 				template:        subTemplate,
 				singleNamespace: false,
 			}
-			crdName      = "knativeeventings.eventing.knative.dev"
-			crName       = "KnativeEventing"
-			podLabelName = "knative-eventing-operator"
+			crdName      = "virtualdatabases.teiid.io"
+			crName       = "VirtualDatabase"
+			podLabelName = "teiid"
 			cl           = checkList{}
 		)
 


### PR DESCRIPTION
@jianzhangbjz @bandrade @tbuskey @scolange could you please review it? thanks
```console
I0617 20:26:32.884557   41284 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0617 20:26:39.500254   41286 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/2) "[sig-operators] an end user handle OLM within a namespace High-24870-can not create csv without operator group [Suite:openshift/conformance/parallel]"

started: (0/2/2) "[sig-operators] an end user handle OLM within all namespace High-25679-Medium-21418-Cluster resource created and deleted correctly [Suite:openshift/conformance/parallel]"

passed: (1m4s) 2020-06-17T12:27:43 "[sig-operators] an end user handle OLM within all namespace High-25679-Medium-21418-Cluster resource created and deleted correctly [Suite:openshift/conformance/parallel]"

passed: (1m15s) 2020-06-17T12:27:54 "[sig-operators] an end user handle OLM within a namespace High-24870-can not create csv without operator group [Suite:openshift/conformance/parallel]"


Timeline:

Jun 17 12:26:43.381 I ns/openshift-config-operator deployment/openshift-config-operator openshift-config-managed/kube-cloud-config ConfigMap was deleted as no longer required (1133 times)
Jun 17 12:27:15.034 I ns/openshift-operators clusterserviceversion/teiid.v0.3.0 requirements not yet checked
Jun 17 12:27:15.057 I ns/openshift-operators clusterserviceversion/teiid.v0.3.0 one or more requirements couldn't be found
Jun 17 12:27:17.907 I ns/openshift-operators clusterserviceversion/teiid.v0.3.0 all requirements found, attempting install
Jun 17 12:27:18.130 I ns/openshift-operators deployment/teiid-operator Scaled up replica set teiid-operator-65d657cdff to 1
Jun 17 12:27:18.155 I ns/openshift-operators clusterserviceversion/teiid.v0.3.0 waiting for install components to report healthy
Jun 17 12:27:18.382 I ns/openshift-operators replicaset/teiid-operator-65d657cdff Created pod: teiid-operator-65d657cdff-r7xpg
Jun 17 12:27:18.386 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg node/ created
Jun 17 12:27:18.594 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg Successfully assigned openshift-operators/teiid-operator-65d657cdff-r7xpg to ip-10-0-128-148.us-east-2.compute.internal
Jun 17 12:27:18.810 I ns/openshift-operators clusterserviceversion/teiid.v0.3.0 installing: waiting for deployment teiid-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n
Jun 17 12:27:20.298 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg Add eth0 [10.128.2.18/23]
Jun 17 12:27:20.512 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg Pulling image "quay.io/teiid/teiid-operator:0.3.0"
Jun 17 12:27:22.205 I ns/openshift-config-operator deployment/openshift-config-operator openshift-config-managed/kube-cloud-config ConfigMap was deleted as no longer required (1134 times)
Jun 17 12:27:22.213 I ns/openshift-config-operator deployment/openshift-config-operator openshift-config-managed/kube-cloud-config ConfigMap was deleted as no longer required (1135 times)
Jun 17 12:27:22.238 I ns/openshift-config-operator deployment/openshift-config-operator openshift-config-managed/kube-cloud-config ConfigMap was deleted as no longer required (1136 times)
Jun 17 12:27:22.338 I ns/openshift-config-operator deployment/openshift-config-operator openshift-config-managed/kube-cloud-config ConfigMap was deleted as no longer required (1137 times)
Jun 17 12:27:22.354 I ns/openshift-config-operator deployment/openshift-config-operator openshift-config-managed/kube-cloud-config ConfigMap was deleted as no longer required (1138 times)
Jun 17 12:27:29.203 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg Successfully pulled image "quay.io/teiid/teiid-operator:0.3.0"
Jun 17 12:27:29.345 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg Created container teiid-operator
Jun 17 12:27:29.382 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg Started container teiid-operator
Jun 17 12:27:29.987 I ns/openshift-operators clusterserviceversion/teiid.v0.3.0 install strategy completed with no errors
Jun 17 12:27:37.280 W ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg node/ip-10-0-128-148.us-east-2.compute.internal graceful deletion within 30s
Jun 17 12:27:37.300 I ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg Stopping container teiid-operator
Jun 17 12:27:40.948 W ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg node/ip-10-0-128-148.us-east-2.compute.internal invariant violation (bug): pod should not transition Running->Pending even when terminated
Jun 17 12:27:40.948 W ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg node/ip-10-0-128-148.us-east-2.compute.internal container=teiid-operator container stopped being ready
Jun 17 12:27:43.373 I ns/openshift-config-operator deployment/openshift-config-operator openshift-config-managed/kube-cloud-config ConfigMap was deleted as no longer required (1139 times)
Jun 17 12:27:48.900 W ns/openshift-operators pod/teiid-operator-65d657cdff-r7xpg node/ip-10-0-128-148.us-east-2.compute.internal deleted

Writing JUnit report to junit_e2e_20200617-122754.xml

2 pass, 0 skip (1m15s)
```