### PR TITLE
fix 25679 for release-4.4

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -472,22 +472,23 @@ var _ = g.Describe("[sig-operators] an end user handle OLM within all namespace"
 		var (
 			itName = g.CurrentGinkgoTestDescription().TestText
 			sub    = subscriptionDescription{
-				name:                   "knative-eventing-operator",
+				name:                   "teiid",
 				namespace:              "openshift-operators",
-				channel:                "alpha",
+				channel:                "beta",
 				ipApproval:             "Automatic",
-				operator:               "knative-eventing-operator",
+				operator:               "teiid",
 				catalogSourceName:      "community-operators",
 				catalogSourceNamespace: "openshift-marketplace",
-				// startingCSV:            "knative-eventing-operator.v0.12.0",
+				// startingCSV:            "teiid.v0.3.0",
 				startingCSV:     "", //get it from package based on currentCSV if ipApproval is Automatic
 				currentCSV:      "",
 				installedCSV:    "",
 				template:        subTemplate,
 				singleNamespace: false,
 			}
-			crdName      = "knativeeventings.eventing.knative.dev"
-			podLabelName = "knative-eventing-operator"
+			crdName      = "virtualdatabases.teiid.io"
+			crName       = "VirtualDatabase"
+			podLabelName = "teiid"
 			cl           = checkList{}
 		)
 
@@ -509,7 +510,7 @@ var _ = g.Describe("[sig-operators] an end user handle OLM within all namespace"
 
 		// OCP-21418
 		g.By("Check no resource of new crd")
-		cl.add(newCheck("present", asAdmin, withNamespace, notPresent, "", ok, []string{"KnativeEventing"}))
+		cl.add(newCheck("present", asAdmin, withNamespace, notPresent, "", ok, []string{crName}))
 		//do check parallelly
 		cl.check(oc)
 		cl.empty()


### PR DESCRIPTION
@jianzhangbjz could you please review it? thanks
knative-eventing-operator is not used any more, so change to teiid to fix case

the fix is already for release-4.5, but that fix has conflict with the code of release-4.4, so make this PR to fix the issue on release-4.4

```console
started: (0/1/1) "[sig-operators] an end user handle OLM within all namespace High-25679-Medium-21418-Cluster resource created and deleted correctly [Suite:openshift/conformance/parallel]"

I0701 14:24:09.836651   45973 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Jul  1 14:24:09.862: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Jul  1 14:24:11.763: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Jul  1 14:24:12.583: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Jul  1 14:24:12.583: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Jul  1 14:24:12.583: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Jul  1 14:24:12.859: INFO: e2e test version: v0.0.0-master+$Format:%h$
Jul  1 14:24:13.323: INFO: kube-apiserver version: v1.17.1+1aa1c48
Jul  1 14:24:14.379: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [sig-operators] an end user handle OLM within all namespace
  /Users/kuiwang/GoProject/go-origin/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [sig-operators] an end user handle OLM within all namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/client.go:111
Jul  1 14:24:17.128: INFO: configPath is now "/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/configfile262948167"
Jul  1 14:24:17.128: INFO: The user is now "e2e-test-olm-all-kre4wo0e-6d6pt-user"
Jul  1 14:24:17.128: INFO: Creating project "e2e-test-olm-all-kre4wo0e-6d6pt"
Jul  1 14:24:17.664: INFO: Waiting on permissions in project "e2e-test-olm-all-kre4wo0e-6d6pt" ...
Jul  1 14:24:17.908: INFO: Waiting for ServiceAccount "default" to be provisioned...
Jul  1 14:24:18.387: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Jul  1 14:24:18.754: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Jul  1 14:24:19.119: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Jul  1 14:24:19.698: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Jul  1 14:24:20.294: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Jul  1 14:24:21.807: INFO: Project "e2e-test-olm-all-kre4wo0e-6d6pt" has been fully provisioned.
[BeforeEach] [sig-operators] an end user handle OLM within all namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:459
[It] High-25679-Medium-21418-Cluster resource created and deleted correctly [Suite:openshift/conformance/parallel]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:471
STEP: Create operator targeted at all namespace
Jul  1 14:24:25.643: INFO: the result of queried resource:teiid.v0.3.0
Jul  1 14:24:29.548: INFO: the file of resource is /tmp/e2e-test-olm-all-kre4wo0e-6d6pt-olm-config.json
subscription.operators.coreos.com/teiid created
Jul  1 14:24:48.636: INFO: the queried resource:AtLatestKnown
Jul  1 14:24:48.636: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
Jul  1 14:24:52.482: INFO: the result of queried resource:teiid.v0.3.0
Jul  1 14:24:52.482: INFO: the installed CSV name is teiid.v0.3.0
STEP: Check the cluster resource rolebinding, role and service account exists
Jul  1 14:24:56.450: INFO: the result of queried resource:teiid.v0.3.0-5b955ccb64-67b677c667 teiid.v0.3.0-5b955ccb64 teiid-operator
STEP: Check the pods of the operator is running
STEP: Check no resource of new crd
STEP: Delete the operator
Jul  1 14:25:06.771: INFO: Error running /Users/kuiwang/work/bin/oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get sub teiid -n openshift-operators:
Error from server (NotFound): subscriptions.operators.coreos.com "teiid" not found
Jul  1 14:25:06.771: INFO: the resource is delete successfully
Jul  1 14:25:13.618: INFO: Error running /Users/kuiwang/work/bin/oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get csv teiid.v0.3.0 -n openshift-operators:
Error from server (NotFound): clusterserviceversions.operators.coreos.com "teiid.v0.3.0" not found
Jul  1 14:25:13.618: INFO: the resource is delete successfully
STEP: Check the cluster resource rolebinding, role and service account do not exist
STEP: Check the CRD still exists
STEP: Check the pods of the operator is deleted
[AfterEach] [sig-operators] an end user handle OLM within all namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/client.go:102
Jul  1 14:25:13.912: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-all-kre4wo0e-6d6pt-user}, err: <nil>
Jul  1 14:25:14.218: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-all-kre4wo0e-6d6pt}, err: <nil>
Jul  1 14:25:14.481: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  M0JZcvzjSeuEPRbMHvXAQwAAAAAAAAAA}, err: <nil>
[AfterEach] [sig-operators] an end user handle OLM within all namespace
  /Users/kuiwang/GoProject/go-origin/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Jul  1 14:25:14.481: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-all-kre4wo0e-6d6pt" for this suite.
[AfterEach] [sig-operators] an end user handle OLM within all namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:464
Jul  1 14:25:16.248: INFO: Running AfterSuite actions on all nodes
Jul  1 14:25:16.248: INFO: Running AfterSuite actions on node 1

passed: (1m29s) 2020-07-01T06:25:16 "[sig-operators] an end user handle OLM within all namespace High-25679-Medium-21418-Cluster resource created and deleted correctly [Suite:openshift/conformance/parallel]"

Writing JUnit report to junit_e2e_20200701-062516.xml

1 pass, 0 skip (1m29s)

```