### PR TITLE
ISV Intermediate Tests for AMQ Streams

### DIFF
--- a/test/extended/isv/isv_intermediate_tests.go
+++ b/test/extended/isv/isv_intermediate_tests.go
@@ -1,0 +1,63 @@
+package isv
+
+import (
+	"path/filepath"
+	"time"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/openshift-tests/test/extended/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[Suite:openshift/isv][Intermediate] Operator", func() {
+	var (
+		oc = exutil.NewCLI("isv", exutil.KubeConfigPath())
+	)
+
+	g.It("AMQ-Streams should work properly", func() {
+		kafkaCR := "Kafka"
+		kafkaClusterName := "my-cluster"
+		kafkaPackageName := "amq-streams"
+		kafkaFile := "kafka.yaml"
+		namespace := "amq-streams"
+		currentPackage := createSubscription(kafkaPackageName, oc, false, namespace)
+
+		checkDeployment(currentPackage, oc)
+		createCR(kafkaFile, oc)
+		checkCR(currentPackage, kafkaCR, kafkaClusterName, oc)
+		removeCR(currentPackage, kafkaCR, kafkaClusterName, oc)
+		removeOperatorDependencies(currentPackage, oc, false)
+		removeNamespace(currentPackage.namespace, oc)
+	})
+
+})
+
+func createCR(filename string, oc *exutil.CLI) {
+	buildPruningBaseDir := exutil.FixturePath("testdata", "isv")
+	cr := filepath.Join(buildPruningBaseDir, filename)
+	err := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", cr).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+func removeCR(p packagemanifest, CRName string, instanceName string, oc *exutil.CLI) {
+	msg, err := oc.SetNamespace(p.namespace).AsAdmin().Run("delete").Args(CRName, instanceName).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(msg).To(o.ContainSubstring("deleted"))
+}
+
+func checkCR(p packagemanifest, CRName string, instanceName string, oc *exutil.CLI) {
+	poolErr := wait.Poll(10*time.Second, 300*time.Second, func() (bool, error) {
+		msg, _ := oc.SetNamespace(p.namespace).AsAdmin().Run("get").Args(CRName, instanceName, "-o=jsonpath={.status.conditions[0].type}").Output()
+		if msg == "Ready" {
+			return true, nil
+		}
+		return false, nil
+	})
+	if poolErr != nil {
+		e2e.Logf("Could not get CR " + CRName + " for " + p.csvVersion)
+		removeCR(p, CRName, instanceName, oc)
+		removeOperatorDependencies(p, oc, false)
+		g.Fail("Could not get CR " + CRName + " for " + p.csvVersion)
+	}
+}

--- a/test/extended/testdata/isv/kafka.yaml
+++ b/test/extended/testdata/isv/kafka.yaml
@@ -1,0 +1,23 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  name: my-cluster
+  labels: {}
+  namespace: amq-streams
+spec:
+  kafka:
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      log.message.format.version: '2.5'
+    version: 2.5.0
+    storage:
+      type: ephemeral
+    listeners:
+      plain: {}
+    replicas: 3
+  zookeeper:
+    storage:
+      type: ephemeral
+    replicas: 3


### PR DESCRIPTION
This PR contains the framework to cover Intermediate tests [1] for ISV Operators and also a sample implementation for AMQ Streams Operator.
Basic Flow:
1) Installs the Operator via Subscription
2) Create the core custom resources
3) Delete the core custom resources
4) Uninstalls the Operator

@tbuskey @mffiedler @jianzhangbjz @scolange  @kuiwang02 , can you please review it? Thanks

Sample Execution:
```
./bin/extended-platform-tests run openshift/isv --dry-run | grep "AMQ" | ./bin/extended-platform-tests run -f -
I0708 17:17:42.765359    4534 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0708 17:17:43.896128    4536 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[Suite:openshift/isv][Intermediate] Operator AMQ-Streams should work properly"

I0708 17:17:54.121950    4871 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Jul  8 17:17:54.163: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Jul  8 17:17:54.727: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Jul  8 17:17:55.252: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Jul  8 17:17:55.252: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Jul  8 17:17:55.252: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Jul  8 17:17:55.482: INFO: e2e test version: v0.0.0-master+$Format:%h$
Jul  8 17:17:55.644: INFO: kube-apiserver version: v1.18.3+a377312
Jul  8 17:17:55.816: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /home/bandrade/go/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [Suite:openshift/isv][Intermediate] Operator
  /home/bandrade/go/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [Suite:openshift/isv][Intermediate] Operator
  /home/bandrade/go/src/github.com/openshift/openshift-tests/test/extended/util/client.go:111
Jul  8 17:17:57.314: INFO: configPath is now "/tmp/configfile105150114"
Jul  8 17:17:57.314: INFO: The user is now "e2e-test-isv-wdltf-user"
Jul  8 17:17:57.314: INFO: Creating project "e2e-test-isv-wdltf"
Jul  8 17:17:57.620: INFO: Waiting on permissions in project "e2e-test-isv-wdltf" ...
Jul  8 17:17:57.787: INFO: Waiting for ServiceAccount "default" to be provisioned...
Jul  8 17:17:58.102: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Jul  8 17:17:58.371: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Jul  8 17:17:58.647: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Jul  8 17:17:58.982: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Jul  8 17:17:59.323: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Jul  8 17:17:59.658: INFO: Project "e2e-test-isv-wdltf" has been fully provisioned.
[It] AMQ-Streams should work properly
  /home/bandrade/go/src/github.com/openshift/openshift-tests/test/extended/isv/isv_intermediate_tests.go:19
Jul  8 17:18:06.399: INFO: Subscription: apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: amq-streams
  namespace: amq-streams
spec:
  channel: "stable"
  installPlanApproval: Automatic
  name: amq-streams
  source: redhat-operators
  sourceNamespace: openshift-marketplace
  startingCSV: amqstreams.v1.5.0
kafka.kafka.strimzi.io/my-cluster created
Jul  8 17:19:41.588: INFO: IP: install-9zfgd
Jul  8 17:19:42.619: INFO: CSVS: amqstreams.v1.5.0
Jul  8 17:19:42.619: INFO: CSV_: amqstreams.v1.5.0
Jul  8 17:19:44.258: INFO: SUBS OUTPUT: amq-streams
Jul  8 17:19:44.258: INFO: SUBS: [amq-streams]
Jul  8 17:19:44.258: INFO: SUB_: amq-streams
Jul  8 17:20:21.344: INFO: Error running /usr/bin/oc --kubeconfig=/home/bandrade/QE/test_execution/kubeconfig.11 get ns amq-streams:
Error from server (NotFound): namespaces "amq-streams" not found
[AfterEach] [Suite:openshift/isv][Intermediate] Operator
  /home/bandrade/go/src/github.com/openshift/openshift-tests/test/extended/util/client.go:102
Jul  8 17:20:21.885: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-isv-wdltf-user}, err: <nil>
Jul  8 17:20:22.065: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-isv-wdltf}, err: <nil>
Jul  8 17:20:22.241: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  _recVmvqQ46b7jcEJd7wCwAAAAAAAAAA}, err: <nil>
[AfterEach] [Suite:openshift/isv][Intermediate] Operator
  /home/bandrade/go/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Jul  8 17:20:22.241: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-isv-wdltf" for this suite.
Jul  8 17:20:22.988: INFO: Running AfterSuite actions on all nodes
Jul  8 17:20:22.988: INFO: Running AfterSuite actions on node 1

passed: (2m39s) 2020-07-08T20:20:23 "[Suite:openshift/isv][Intermediate] Operator AMQ-Streams should work properly"

```

[1] https://github.com/openshift/osde2e#operator-testing 