### PR TITLE
change catsrc and version of elasticsearch for release 4.6

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -566,11 +566,12 @@ var _ = g.Describe("[sig-operators] an end user handle OLM within all namespace"
 				channel:                "preview",
 				ipApproval:             "Automatic",
 				operator:               "elasticsearch-operator",
-				catalogSourceName:      "qe-app-registry",
+				catalogSourceName:      "redhat-operators",
 				catalogSourceNamespace: "openshift-marketplace",
 				// startingCSV:            "elasticsearch-operator.4.1.37-202003021622",
-				startingCSV:     "", //get it from package based on currentCSV if ipApproval is Automatic
-				currentCSV:      "",
+				startingCSV: "", //get it from package based on currentCSV if ipApproval is Automatic
+				// currentCSV:  "",
+				currentCSV:      "elasticsearch-operator.4.1.41-202004130646",
 				installedCSV:    "",
 				template:        subTemplate,
 				singleNamespace: false,


### PR DESCRIPTION
the operator elasticsearch package is changed, so modify the case to make it pass.

@jianzhangbjz @bandrade @tbuskey could you please help review it? thanks

```console
14:59:05 started: (0/1/1) "[sig-operators] an end user handle OLM within all namespace High-25783-Subscriptions are not getting processed taking very long to get processed [Serial] [Suite:openshift/conformance/serial]"
14:59:05 
15:00:11 I0723 06:59:10.789382    3760 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
15:00:11 Jul 23 06:59:10.835: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
15:00:11 Jul 23 06:59:10.895: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
15:00:11 Jul 23 06:59:10.977: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
15:00:11 Jul 23 06:59:10.977: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
15:00:11 Jul 23 06:59:10.977: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
15:00:11 Jul 23 06:59:11.005: INFO: e2e test version: v0.0.0-master+$Format:%h$
15:00:11 Jul 23 06:59:11.024: INFO: kube-apiserver version: v4.6.0-202007202229.p0-dirty
15:00:11 Jul 23 06:59:11.050: INFO: Cluster IP family: ipv4
15:00:11 [BeforeEach] [Top Level]
15:00:11   /home/jenkins/workspace/ginkgo-test/public/test/extended/util/test.go:60
15:00:11 [BeforeEach] [sig-operators] an end user handle OLM within all namespace
15:00:11   /goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
15:00:11 STEP: Creating a kubernetes client
15:00:11 [BeforeEach] [sig-operators] an end user handle OLM within all namespace
15:00:11   /home/jenkins/workspace/ginkgo-test/public/test/extended/util/client.go:111
15:00:11 Jul 23 06:59:11.267: INFO: configPath is now "/tmp/configfile036019529"
15:00:11 Jul 23 06:59:11.267: INFO: The user is now "e2e-test-olm-all-nyda10qe-nvqjh-user"
15:00:11 Jul 23 06:59:11.267: INFO: Creating project "e2e-test-olm-all-nyda10qe-nvqjh"
15:00:11 Jul 23 06:59:11.367: INFO: Waiting on permissions in project "e2e-test-olm-all-nyda10qe-nvqjh" ...
15:00:11 Jul 23 06:59:11.390: INFO: Waiting for ServiceAccount "default" to be provisioned...
15:00:11 Jul 23 06:59:11.514: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
15:00:11 Jul 23 06:59:11.637: INFO: Waiting for ServiceAccount "builder" to be provisioned...
15:00:11 Jul 23 06:59:11.761: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
15:00:11 Jul 23 06:59:11.805: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
15:00:11 Jul 23 06:59:11.847: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
15:00:11 Jul 23 06:59:11.890: INFO: Project "e2e-test-olm-all-nyda10qe-nvqjh" has been fully provisioned.
15:00:11 [BeforeEach] [sig-operators] an end user handle OLM within all namespace
15:00:11   /home/jenkins/workspace/ginkgo-test/public/test/extended/operators/olm.go:477
15:00:11 [It] High-25783-Subscriptions are not getting processed taking very long to get processed [Serial] [Suite:openshift/conformance/serial]
15:00:11   /home/jenkins/workspace/ginkgo-test/public/test/extended/operators/olm.go:560
15:00:11 STEP: create operator ElasticSearch
15:00:11 Jul 23 06:59:15.706: INFO: the file of resource is /tmp/e2e-test-olm-all-nyda10qe-nvqjh-gzkssxe6olm-config.json
15:00:11 subscription.operators.coreos.com/elasticsearch-operator created
15:00:11 Jul 23 06:59:20.031: INFO: the queried resource:UpgradePending
15:00:11 Jul 23 06:59:23.074: INFO: the queried resource:AtLatestKnown
15:00:11 Jul 23 06:59:23.074: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
15:00:11 Jul 23 06:59:26.304: INFO: the result of queried resource:elasticsearch-operator.4.1.41-202004130646
15:00:11 Jul 23 06:59:26.304: INFO: the installed CSV name is elasticsearch-operator.4.1.41-202004130646
15:00:11 Jul 23 06:59:29.589: INFO: the queried resource:Succeeded
15:00:11 Jul 23 06:59:29.589: INFO: the output Succeeded matches one of the content Succeeded, expected
15:00:11 STEP: create operator Jaeger
15:00:11 Jul 23 06:59:32.848: INFO: the result of queried resource:jaeger-operator.v1.17.5
15:00:11 Jul 23 06:59:36.081: INFO: the file of resource is /tmp/e2e-test-olm-all-nyda10qe-nvqjh-i9bsaostolm-config.json
15:00:11 subscription.operators.coreos.com/jaeger-product created
15:00:11 Jul 23 06:59:40.442: INFO: the queried resource:UpgradePending
15:00:11 Jul 23 06:59:43.472: INFO: the queried resource:AtLatestKnown
15:00:11 Jul 23 06:59:43.472: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
15:00:11 Jul 23 06:59:46.761: INFO: the result of queried resource:jaeger-operator.v1.17.5
15:00:11 Jul 23 06:59:46.761: INFO: the installed CSV name is jaeger-operator.v1.17.5
15:00:11 Jul 23 06:59:50.022: INFO: the queried resource:Succeeded
15:00:11 Jul 23 06:59:50.022: INFO: the output Succeeded matches one of the content Succeeded, expected
15:00:11 Jul 23 06:59:53.589: INFO: Error running /usr/bin/oc --kubeconfig=/home/jenkins/kubeconf/kubeconfig get sub jaeger-product -n openshift-operators:
15:00:11 Error from server (NotFound): subscriptions.operators.coreos.com "jaeger-product" not found
15:00:11 Jul 23 06:59:53.589: INFO: the resource is delete successfully
15:00:11 Jul 23 06:59:57.122: INFO: Error running /usr/bin/oc --kubeconfig=/home/jenkins/kubeconf/kubeconfig get csv jaeger-operator.v1.17.5 -n openshift-operators:
15:00:11 Error from server (NotFound): clusterserviceversions.operators.coreos.com "jaeger-operator.v1.17.5" not found
15:00:11 Jul 23 06:59:57.122: INFO: the resource is delete successfully
15:00:11 Jul 23 07:00:00.777: INFO: Error running /usr/bin/oc --kubeconfig=/home/jenkins/kubeconf/kubeconfig get crd jaegers.jaegertracing.io:
15:00:11 Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "jaegers.jaegertracing.io" not found
15:00:11 Jul 23 07:00:00.777: INFO: the resource is delete successfully
15:00:11 Jul 23 07:00:04.298: INFO: Error running /usr/bin/oc --kubeconfig=/home/jenkins/kubeconf/kubeconfig get sub elasticsearch-operator -n openshift-operators:
15:00:11 Error from server (NotFound): subscriptions.operators.coreos.com "elasticsearch-operator" not found
15:00:11 Jul 23 07:00:04.298: INFO: the resource is delete successfully
15:00:11 Jul 23 07:00:07.881: INFO: Error running /usr/bin/oc --kubeconfig=/home/jenkins/kubeconf/kubeconfig get csv elasticsearch-operator.4.1.41-202004130646 -n openshift-operators:
15:00:11 Error from server (NotFound): clusterserviceversions.operators.coreos.com "elasticsearch-operator.4.1.41-202004130646" not found
15:00:11 Jul 23 07:00:07.881: INFO: the resource is delete successfully
15:00:11 Jul 23 07:00:11.406: INFO: Error running /usr/bin/oc --kubeconfig=/home/jenkins/kubeconf/kubeconfig get crd elasticsearches.logging.openshift.io:
15:00:11 Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "elasticsearches.logging.openshift.io" not found
15:00:11 Jul 23 07:00:11.406: INFO: the resource is delete successfully
15:00:11 [AfterEach] [sig-operators] an end user handle OLM within all namespace
15:00:11   /home/jenkins/workspace/ginkgo-test/public/test/extended/util/client.go:102
15:00:11 Jul 23 07:00:11.437: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-all-nyda10qe-nvqjh-user}, err: <nil>
15:00:11 Jul 23 07:00:11.466: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-all-nyda10qe-nvqjh}, err: <nil>
15:00:11 Jul 23 07:00:11.498: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  RUQbfPZgQLCdNpSqL7DI_AAAAAAAAAAA}, err: <nil>
15:00:11 [AfterEach] [sig-operators] an end user handle OLM within all namespace
15:00:11   /goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
15:00:11 Jul 23 07:00:11.499: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
15:00:11 STEP: Destroying namespace "e2e-test-olm-all-nyda10qe-nvqjh" for this suite.
15:00:11 [AfterEach] [sig-operators] an end user handle OLM within all namespace
15:00:11   /home/jenkins/workspace/ginkgo-test/public/test/extended/operators/olm.go:482
15:00:11 Jul 23 07:00:11.600: INFO: Running AfterSuite actions on all nodes
15:00:11 Jul 23 07:00:11.600: INFO: Running AfterSuite actions on node 1
15:00:11 
15:00:11 passed: (1m6s) 2020-07-23T07:00:11 "[sig-operators] an end user handle OLM within all namespace High-25783-Subscriptions are not getting processed taking very long to get processed [Serial] [Suite:openshift/conformance/serial]"
```