### PR TITLE
fixcasefor46

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -78,8 +78,8 @@ var _ = g.Describe("[sig-operators] OLM should", func() {
 				// Ensure expected version exists in spec.versions and is both served and stored
 				raw, err := oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath={.spec.versions[?(@.name==\"%s\")]}", api.version)).Output()
 				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(raw).To(o.ContainSubstring("served:true"))
-				o.Expect(raw).To(o.ContainSubstring("storage:true"))
+				o.Expect(raw).To(o.ContainSubstring("\"served\":true"))
+				o.Expect(raw).To(o.ContainSubstring("\"storage\":true"))
 			}
 		})
 	}


### PR DESCRIPTION
@jianzhangbjz @bandrade could you please review them? thanks

```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run|grep "OLM should be"|./bin/extended-platform-tests run  -f - 
I0812 11:03:10.384672   98818 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0812 11:03:17.450573   98816 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/6) "[sig-operators] OLM should be installed with operatorgroups at version v1 [Suite:openshift/conformance/parallel]"

started: (0/2/6) "[sig-operators] OLM should be installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/3/6) "[sig-operators] OLM should be installed with clusterserviceversions at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (14.2s) 2020-08-12T03:03:31 "[sig-operators] OLM should be installed with clusterserviceversions at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/4/6) "[sig-operators] OLM should be installed with packagemanifests at version v1 [Suite:openshift/conformance/parallel]"

passed: (15.7s) 2020-08-12T03:03:33 "[sig-operators] OLM should be installed with operatorgroups at version v1 [Suite:openshift/conformance/parallel]"

started: (0/5/6) "[sig-operators] OLM should be installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (23.4s) 2020-08-12T03:03:40 "[sig-operators] OLM should be installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/6/6) "[sig-operators] OLM should be installed with installplans at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (13.2s) 2020-08-12T03:03:44 "[sig-operators] OLM should be installed with packagemanifests at version v1 [Suite:openshift/conformance/parallel]"

passed: (13.9s) 2020-08-12T03:03:47 "[sig-operators] OLM should be installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]"

passed: (11s) 2020-08-12T03:03:51 "[sig-operators] OLM should be installed with installplans at version v1alpha1 [Suite:openshift/conformance/parallel]"

6 pass, 0 skip (34.4s)

```