### PR TITLE
apply the name rule for OLM cases

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -144,7 +144,7 @@ var _ = g.Describe("[sig-operators] OLM should", func() {
 
 })
 
-var _ = g.Describe("[sig-operators] an end user use OLM", func() {
+var _ = g.Describe("[sig-operators] OLM for an end user use", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -207,7 +207,7 @@ var _ = g.Describe("[sig-operators] an end user use OLM", func() {
 
 })
 
-var _ = g.Describe("[sig-operators] an end user handle OLM within a namespace", func() {
+var _ = g.Describe("[sig-operators] OLM for an end user handle within a namespace", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -306,7 +306,7 @@ var _ = g.Describe("[sig-operators] an end user handle OLM within a namespace", 
 
 })
 
-var _ = g.Describe("[sig-operators] an end user handle OLM to support", func() {
+var _ = g.Describe("[sig-operators] OLM for an end user handle to support", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -448,7 +448,7 @@ var _ = g.Describe("[sig-operators] an end user handle OLM to support", func() {
 
 })
 
-var _ = g.Describe("[sig-operators] an end user handle OLM within all namespace", func() {
+var _ = g.Describe("[sig-operators] OLM for an end user handle within all namespace", func() {
 	defer g.GinkgoRecover()
 
 	var (


### PR DESCRIPTION
the OLM cases are created before defining name rule, so it does not follow it. 
The PR apply name rule for the OLM cases

@jianzhangbjz @bandrade could you please review it? thanks

```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run|grep -E 'OLM'   
I0903 11:24:06.397586   85979 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
"[sig-operators] OLM for an end user handle to support High-22226-the csv without support AllNamespaces fails for og with allnamespace [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM for an end user handle to support High-22226-the csv without support MultiNamespace fails for og with MultiNamespace [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM for an end user handle within a namespace High-24870-can not create csv without operator group [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM for an end user handle within a namespace High-25855-Add the channel field to subscription_sync_count [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM for an end user handle within all namespace High-25679-Medium-21418-Cluster resource created and deleted correctly [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM for an end user handle within all namespace High-25783-Subscriptions are not getting processed taking very long to get processed [Serial] [Suite:openshift/conformance/serial]"
"[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-24061-have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-24829-Report Upgradeable in OLM ClusterOperators status [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-27589-do not use ipv4 addresses in CatalogSources generated by marketplace [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should be installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should be installed with clusterserviceversions at version v1alpha1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should be installed with installplans at version v1alpha1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should be installed with operatorgroups at version v1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should be installed with packagemanifests at version v1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should be installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]"
```