### PR TITLE
apply name rule for marketplace case

### DIFF
--- a/test/extended/marketplace/marketplace_diffname.go
+++ b/test/extended/marketplace/marketplace_diffname.go
@@ -13,7 +13,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[sig-operators] Marketplace should", func() {
+var _ = g.Describe("[sig-operators] OLM Marketplace should", func() {
 
 	defer g.GinkgoRecover()
 
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-operators] Marketplace should", func() {
 	})
 
 	// author: jfan@redhat.com
-	g.It("OLM-Medium-ocp-25672-create the samename opsrc&csc", func() {
+	g.It("Medium-25672-create the samename opsrc&csc", func() {
 
 		// Create one opsrc samename
 		opsrcYaml, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", opsrcYamltem, "-p", "NAME=samename", "NAMESPACE=marketplace_e2e", "LABEL=samename", "DISPLAYNAME=samename", "PUBLISHER=samename", fmt.Sprintf("MARKETPLACE=%s", marketplaceNs)).OutputToFile("config.json")

--- a/test/extended/marketplace/marketplace_lables.go
+++ b/test/extended/marketplace/marketplace_lables.go
@@ -13,7 +13,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = g.Describe("[sig-operators] Marketplace could", func() {
+var _ = g.Describe("[sig-operators] OLM Marketplace could", func() {
 
 	defer g.GinkgoRecover()
 
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-operators] Marketplace could", func() {
 	})
 
 	// author: jfan@redhat.com
-	g.It("OLM-High-ocp-21728-create opsrc with labels", func() {
+	g.It("High-21728-create opsrc with labels", func() {
 
 		// Create one opsrc with label
 		opsrcYaml, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", opsrcYamltem, "-p", "NAME=opsrctestlabel", "NAMESPACE=marketplace_e2e", "LABEL=optestlabel", "DISPLAYNAME=optestlabel", "PUBLISHER=optestlabel", fmt.Sprintf("MARKETPLACE=%s", marketplaceNs)).OutputToFile("config.json")


### PR DESCRIPTION
apply name rule for marketplace case for 4.5. and then cherry-pick to 4.4

@jianzhangbjz @bandrade could you please review it? thanks

```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run|grep -E 'OLM Marketplace'
I0903 11:39:28.750899   86480 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
"[sig-operators] OLM Marketplace could High-21728-create opsrc with labels [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM Marketplace should Medium-25672-create the samename opsrc&csc [Suite:openshift/conformance/parallel]"
```