### PR TITLE
add case id for old dev case

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-operators] OLM should", func() {
 
 	for i := range providedAPIs {
 		api := providedAPIs[i]
-		g.It(fmt.Sprintf("be installed with %s at version %s", api.plural, api.version), func() {
+		g.It(fmt.Sprintf("High-36803-OLM is installed with %s at version %s", api.plural, api.version), func() {
 			if api.fromAPIService {
 				// Ensure spec.version matches expected
 				raw, err := oc.AsAdmin().Run("get").Args("apiservices", fmt.Sprintf("%s.%s", api.version, api.group), "-o=jsonpath={.spec.version}").Output()


### PR DESCRIPTION
@jianzhangbjz could you please review it? thanks
```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run |grep "OLM should"|grep installed
I1117 17:36:33.740022   99415 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
"[sig-operators] OLM should High-36803-OLM is installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-36803-OLM is installed with clusterserviceversions at version v1alpha1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-36803-OLM is installed with installplans at version v1alpha1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-36803-OLM is installed with operatorgroups at version v1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-36803-OLM is installed with packagemanifests at version v1 [Suite:openshift/conformance/parallel]"
"[sig-operators] OLM should High-36803-OLM is installed with subscriptions at version v1alpha1 [Suite:openshift/conformance/parallel]"
```