### PR TITLE
fix 23440

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -1,19 +1,14 @@
 package operators
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
-	"io/ioutil"
-	"math/rand"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	exutil "github.com/openshift/openshift-tests/test/extended/util"
@@ -147,39 +142,36 @@ var _ = g.Describe("[sig-operators] OLM should", func() {
 var _ = g.Describe("[sig-operators] OLM for an end user use", func() {
 	defer g.GinkgoRecover()
 
-	var (
-		oc           = exutil.NewCLI("olm-23440", exutil.KubeConfigPath())
-		operatorWait = 120 * time.Second
+	var oc = exutil.NewCLI("olm", exutil.KubeConfigPath())
 
-		buildPruningBaseDir = exutil.FixturePath("testdata", "olm")
-		operatorGroup       = filepath.Join(buildPruningBaseDir, "operatorgroup.yaml")
-		etcdSub             = filepath.Join(buildPruningBaseDir, "etcd-subscription.yaml")
-		etcdCluster         = filepath.Join(buildPruningBaseDir, "etcd-cluster.yaml")
-	)
-
-	files := []string{operatorGroup, etcdSub}
 	// author: jiazha@redhat.com
 	g.It("Critical-23440-can subscribe to the etcd operator", func() {
-		g.By("Cluster-admin user subscribe the operator resource")
-		for _, v := range files {
-			configFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", v, "-p", "NAME=test-operator", fmt.Sprintf("NAMESPACE=%s", oc.Namespace()), "SOURCENAME=community-operators", "SOURCENAMESPACE=openshift-marketplace").OutputToFile("config.json")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", configFile).Execute()
-			o.Expect(err).NotTo(o.HaveOccurred())
+		buildPruningBaseDir := exutil.FixturePath("testdata", "olm")
+		etcdCluster := filepath.Join(buildPruningBaseDir, "etcd-cluster.yaml")
+		subTemplate := filepath.Join(buildPruningBaseDir, "olm-subscription.yaml")
+		oc.SetupProject()
 
+		dr := make(describerResrouce)
+		itName := g.CurrentGinkgoTestDescription().TestText
+		dr.addIr(itName)
+
+		g.By("Cluster-admin start to subscribe to etcd operator")
+		sub := subscriptionDescription{
+			subName:                "sub-23440",
+			namespace:              "openshift-operators",
+			catalogSourceName:      "community-operators",
+			catalogSourceNamespace: "openshift-marketplace",
+			channel:                "clusterwide-alpha",
+			ipApproval:             "Automatic",
+			operatorPackage:        "etcd",
+			singleNamespace:        false,
+			template:               subTemplate,
 		}
-		err := wait.Poll(10*time.Second, operatorWait, func() (bool, error) {
-			output, err := oc.AsAdmin().Run("get").Args("-n", oc.Namespace(), "csv", "etcdoperator.v0.9.4", "-o=jsonpath={.status.phase}").Output()
-			if err != nil {
-				e2e.Failf("Failed to deploy etcdoperator.v0.9.4, error:%v", err)
-				return false, err
-			}
-			if strings.Contains(output, "Succeeded") {
-				return true, nil
-			}
-			return false, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
+		sub.create(oc, itName, dr)
+		defer sub.delete(itName, dr)
+		defer sub.getCSV().delete(itName, dr)
+		newCheck("expect", asAdmin, true, compare, "Succeeded", ok, []string{"csv", sub.installedCSV, "-o=jsonpath={.status.phase}"}).check(oc)
+
 
 		g.By("Switch to common user to create the resources provided by the operator")
 		etcdClusterName := "example-etcd-cluster"
@@ -188,23 +180,14 @@ var _ = g.Describe("[sig-operators] OLM for an end user use", func() {
 		err = oc.Run("create").Args("-f", configFile).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		err = wait.Poll(10*time.Second, operatorWait, func() (bool, error) {
-			output, err := oc.Run("get").Args("-n", oc.Namespace(), "etcdCluster", etcdClusterName, "-o=jsonpath={.status}").Output()
-			if err != nil {
-				e2e.Failf("Failed to get etcdCluster, error:%v", err)
-				return false, err
-			}
-			if strings.Contains(output, "phase:Running") && strings.Contains(output, "currentVersion:3.2.13") && strings.Contains(output, "size:3") {
-				return true, nil
-			}
-			return false, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		output, err := oc.Run("get").Args("pods", "-n", oc.Namespace()).Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(output).To(o.ContainSubstring(etcdClusterName))
-	})
+		defer func() {
+			_, err := oc.Run("delete").Args("etcdcluster", etcdClusterName, "-n", oc.Namespace()).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}()
 
+		newCheck("expect", false, true, compare, "Running", ok, []string{"etcdCluster", etcdClusterName, "-o=jsonpath={.status.phase}"}).check(oc)
+
+	})
 })
 
 var _ = g.Describe("[sig-operators] OLM for an end user handle within a namespace", func() {
@@ -224,11 +207,11 @@ var _ = g.Describe("[sig-operators] OLM for an end user handle within a namespac
 			template:  ogSingleTemplate,
 		}
 		subD = subscriptionDescription{
-			name:                   "hawtio-operator",
+			subName:                "hawtio-operator",
 			namespace:              "",
 			channel:                "alpha",
 			ipApproval:             "Automatic",
-			operator:               "hawtio-operator",
+			operatorPackage:        "hawtio-operator",
 			catalogSourceName:      "community-operators",
 			catalogSourceNamespace: "openshift-marketplace",
 			startingCSV:            "",
@@ -335,11 +318,11 @@ var _ = g.Describe("[sig-operators] OLM for an end user handle to support", func
 			template:    catsrcCmTemplate,
 		}
 		subNc = subscriptionDescription{
-			name:                   "namespace-configuration-operator",
+			subName:                "namespace-configuration-operator",
 			namespace:              "", //must be set in iT
 			channel:                "alpha",
 			ipApproval:             "Automatic",
-			operator:               "namespace-configuration-operator",
+			operatorPackage:        "namespace-configuration-operator",
 			catalogSourceName:      "catsrc-community-namespaceconfig-operators",
 			catalogSourceNamespace: "", //must be set in iT
 			startingCSV:            "",
@@ -475,11 +458,11 @@ var _ = g.Describe("[sig-operators] OLM for an end user handle within all namesp
 		var (
 			itName = g.CurrentGinkgoTestDescription().TestText
 			sub    = subscriptionDescription{
-				name:                   "teiid",
+				subName:                "teiid",
 				namespace:              "openshift-operators",
 				channel:                "beta",
 				ipApproval:             "Automatic",
-				operator:               "teiid",
+				operatorPackage:        "teiid",
 				catalogSourceName:      "community-operators",
 				catalogSourceNamespace: "openshift-marketplace",
 				// startingCSV:            "teiid.v0.3.0",
@@ -546,11 +529,11 @@ var _ = g.Describe("[sig-operators] OLM for an end user handle within all namesp
 		var (
 			itName           = g.CurrentGinkgoTestDescription().TestText
 			subElasticSearch = subscriptionDescription{
-				name:                   "elasticsearch-operator",
+				subName:                "elasticsearch-operator",
 				namespace:              "openshift-operators",
 				channel:                "preview",
 				ipApproval:             "Automatic",
-				operator:               "elasticsearch-operator",
+				operatorPackage:        "elasticsearch-operator",
 				catalogSourceName:      "redhat-operators",
 				catalogSourceNamespace: "openshift-marketplace",
 				// startingCSV:            "elasticsearch-operator.4.1.37-202003021622",
@@ -568,11 +551,11 @@ var _ = g.Describe("[sig-operators] OLM for an end user handle within all namesp
 			}
 
 			subJaeger = subscriptionDescription{
-				name:                   "jaeger-product",
+				subName:                "jaeger-product",
 				namespace:              "openshift-operators",
 				channel:                "stable",
 				ipApproval:             "Automatic",
-				operator:               "jaeger-product",
+				operatorPackage:        "jaeger-product",
 				catalogSourceName:      "redhat-operators",
 				catalogSourceNamespace: "openshift-marketplace",
 				// startingCSV:            "jaeger-operator.v1.17.1",
@@ -632,763 +615,3 @@ var _ = g.Describe("[sig-operators] OLM for an end user handle within all namesp
 	})
 
 })
-
-const (
-	asAdmin          = true
-	asUser           = false
-	withoutNamespace = true
-	withNamespace    = false
-	compare          = true
-	contain          = false
-	requireNS        = true
-	notRequireNS     = false
-	present          = true
-	notPresent       = false
-	ok               = true
-	nok              = false
-)
-
-type csvDescription struct {
-	name      string
-	namespace string
-}
-
-func (csv csvDescription) delete(itName string, dr describerResrouce) {
-	dr.getIr(itName).remove(csv.name, "csv", csv.namespace)
-}
-
-type subscriptionDescription struct {
-	name                   string
-	namespace              string
-	channel                string
-	ipApproval             string
-	operator               string
-	catalogSourceName      string
-	catalogSourceNamespace string
-	startingCSV            string
-	currentCSV             string
-	installedCSV           string
-	template               string
-	singleNamespace        bool
-	ipCsv                  string
-}
-
-func (sub *subscriptionDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	sub.createWithoutCheck(oc, itName, dr)
-	if strings.Compare(sub.ipApproval, "Automatic") == 0 {
-		sub.findInstalledCSV(oc, itName, dr)
-	} else {
-		newCheck("expect", asAdmin, withoutNamespace, compare, "UpgradePending", ok, []string{"sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.state}"}).check(oc)
-	}
-}
-
-func (sub *subscriptionDescription) createWithoutCheck(oc *exutil.CLI, itName string, dr describerResrouce) {
-	isAutomatic := strings.Compare(sub.ipApproval, "Automatic") == 0
-	if strings.Compare(sub.currentCSV, "") == 0 {
-		sub.currentCSV = getResource(oc, asAdmin, withoutNamespace, "packagemanifest", sub.name, fmt.Sprintf("-o=jsonpath={.status.channels[?(@.name==\"%s\")].currentCSV}", sub.channel))
-		o.Expect(sub.currentCSV).NotTo(o.BeEmpty())
-	}
-	if isAutomatic {
-		sub.startingCSV = sub.currentCSV
-	} else {
-		o.Expect(sub.startingCSV).NotTo(o.BeEmpty())
-	}
-	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", sub.template, "-p", "SUBNAME="+sub.name, "SUBNAMESPACE="+sub.namespace, "CHANNEL="+sub.channel,
-		"APPROVAL="+sub.ipApproval, "OPERATORNAME="+sub.operator, "SOURCENAME="+sub.catalogSourceName, "SOURCENAMESPACE="+sub.catalogSourceNamespace, "STARTINGCSV="+sub.startingCSV)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "sub", sub.name, requireNS, sub.namespace))
-}
-
-func (sub *subscriptionDescription) findInstalledCSV(oc *exutil.CLI, itName string, dr describerResrouce) {
-	newCheck("expect", asAdmin, withoutNamespace, compare, "AtLatestKnown", ok, []string{"sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.state}"}).check(oc)
-	installedCSV := getResource(oc, asAdmin, withoutNamespace, "sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.installedCSV}")
-	o.Expect(installedCSV).NotTo(o.BeEmpty())
-	if strings.Compare(sub.installedCSV, installedCSV) != 0 {
-		sub.installedCSV = installedCSV
-		dr.getIr(itName).add(newResource(oc, "csv", sub.installedCSV, requireNS, sub.namespace))
-	}
-	e2e.Logf("the installed CSV name is %s", sub.installedCSV)
-}
-
-func (sub *subscriptionDescription) expectCSV(oc *exutil.CLI, itName string, dr describerResrouce, cv string) {
-	err := wait.Poll(3*time.Second, 180*time.Second, func() (bool, error) {
-		sub.findInstalledCSV(oc, itName, dr)
-		if strings.Compare(sub.installedCSV, cv) == 0 {
-			return true, nil
-		}
-		return false, nil
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-func (sub *subscriptionDescription) approve(oc *exutil.CLI, itName string, dr describerResrouce) {
-	err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
-		for strings.Compare(sub.installedCSV, "") == 0 {
-			state := getResource(oc, asAdmin, withoutNamespace, "sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.state}")
-			if strings.Compare(state, "AtLatestKnown") == 0 {
-				sub.installedCSV = getResource(oc, asAdmin, withoutNamespace, "sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.installedCSV}")
-				dr.getIr(itName).add(newResource(oc, "csv", sub.installedCSV, requireNS, sub.namespace))
-				e2e.Logf("it is already done, and the installed CSV name is %s", sub.installedCSV)
-				continue
-			}
-
-			ipCsv := getResource(oc, asAdmin, withoutNamespace, "sub", sub.name, "-n", sub.namespace, "-o=jsonpath={.status.installplan.name}{\" \"}{.status.currentCSV}")
-			sub.ipCsv = ipCsv + "##" + sub.ipCsv
-			installPlan := strings.Fields(ipCsv)[0]
-			o.Expect(installPlan).NotTo(o.BeEmpty())
-			e2e.Logf("try to approve installPlan %s", installPlan)
-			patchResource(oc, asAdmin, withoutNamespace, "ip", installPlan, "-n", sub.namespace, "--type", "merge", "-p", "{\"spec\": {\"approved\": true}}")
-			err := wait.Poll(3*time.Second, 10*time.Second, func() (bool, error) {
-				err := newCheck("expect", asAdmin, withoutNamespace, compare, "Complete", ok, []string{"ip", installPlan, "-n", sub.namespace, "-o=jsonpath={.status.phase}"}).checkWithoutAssert(oc)
-				if err != nil {
-					e2e.Logf("the get error is %v, and try next", err)
-					return false, nil
-				}
-				return true, nil
-			})
-			o.Expect(err).NotTo(o.HaveOccurred())
-		}
-		return true, nil
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-func (sub *subscriptionDescription) getCSV() csvDescription {
-	return csvDescription{sub.installedCSV, sub.namespace}
-}
-
-func (sub *subscriptionDescription) getInstanceVersion(oc *exutil.CLI) string {
-	version := ""
-	output := strings.Split(getResource(oc, asUser, withoutNamespace, "csv", sub.installedCSV, "-n", sub.namespace, "-o=jsonpath={.metadata.annotations.alm-examples}"), "\n")
-	for _, line := range output {
-		if strings.Contains(line, "\"version\"") {
-			version = strings.Trim(strings.Fields(strings.TrimSpace(line))[1], "\"")
-			break
-		}
-	}
-	o.Expect(version).NotTo(o.BeEmpty())
-	return version
-}
-
-func (sub *subscriptionDescription) createInstance(oc *exutil.CLI, instance string) {
-	path := filepath.Join(e2e.TestContext.OutputDir, sub.namespace+"-"+"instance.json")
-	err := ioutil.WriteFile(path, []byte(instance), 0644)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-n", sub.namespace, "-f", path).Execute()
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-func (sub *subscriptionDescription) delete(itName string, dr describerResrouce) {
-	dr.getIr(itName).remove(sub.name, "sub", sub.namespace)
-}
-
-func (sub *subscriptionDescription) patch(oc *exutil.CLI, patch string) {
-	patchResource(oc, asAdmin, withoutNamespace, "sub", sub.name, "-n", sub.namespace, "--type", "merge", "-p", patch)
-}
-
-type crdDescription struct {
-	name     string
-	template string
-}
-
-func (crd *crdDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", crd.template, "-p", "NAME="+crd.name)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "crd", crd.name, notRequireNS, ""))
-}
-
-func (crd *crdDescription) delete(oc *exutil.CLI) {
-	removeResource(oc, asAdmin, withoutNamespace, "crd", crd.name)
-}
-
-type configMapDescription struct {
-	name      string
-	namespace string
-	template  string
-}
-
-func (cm *configMapDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", cm.template, "-p", "NAME="+cm.name, "NAMESPACE="+cm.namespace)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "cm", cm.name, requireNS, cm.namespace))
-}
-func (cm *configMapDescription) patch(oc *exutil.CLI, patch string) {
-	patchResource(oc, asAdmin, withoutNamespace, "cm", cm.name, "-n", cm.namespace, "--type", "merge", "-p", patch)
-}
-
-type catalogSourceDescription struct {
-	name        string
-	namespace   string
-	displayName string
-	publisher   string
-	sourceType  string
-	address     string
-	template    string
-}
-
-func (catsrc *catalogSourceDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", catsrc.template,
-		"-p", "NAME="+catsrc.name, "NAMESPACE="+catsrc.namespace, "ADDRESS="+catsrc.address,
-		"DISPLAYNAME="+"\""+catsrc.displayName+"\"", "PUBLISHER="+"\""+catsrc.publisher+"\"", "SOURCETYPE="+catsrc.sourceType)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "catsrc", catsrc.name, requireNS, catsrc.namespace))
-}
-func (catsrc *catalogSourceDescription) delete(itName string, dr describerResrouce) {
-	dr.getIr(itName).remove(catsrc.name, "catsrc", catsrc.namespace)
-}
-
-type operatorGroupDescription struct {
-	name         string
-	namespace    string
-	multinslabel string
-	template     string
-}
-
-func (og *operatorGroupDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	var err error
-	if strings.Compare(og.multinslabel, "") == 0 {
-		err = applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", og.template, "-p", "NAME="+og.name, "NAMESPACE="+og.namespace)
-	} else {
-		err = applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", og.template, "-p", "NAME="+og.name, "NAMESPACE="+og.namespace, "MULTINSLABEL="+og.multinslabel)
-	}
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "og", og.name, requireNS, og.namespace))
-}
-func (og *operatorGroupDescription) delete(itName string, dr describerResrouce) {
-	dr.getIr(itName).remove(og.name, "og", og.namespace)
-}
-
-type operatorSourceDescription struct {
-	name              string
-	namespace         string
-	namelabel         string
-	registrynamespace string
-	displayname       string
-	publisher         string
-	template          string
-	deploymentName    string
-}
-
-func (osrc *operatorSourceDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", osrc.template, "-p", "NAME="+osrc.name, "NAMESPACE="+osrc.namespace,
-		"NAMELABEL="+osrc.namelabel, "REGISTRYNAMESPACE="+osrc.registrynamespace, "DISPLAYNAME="+osrc.displayname, "PUBLISHER="+osrc.publisher)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "opsrc", osrc.name, requireNS, osrc.namespace))
-}
-
-func (osrc *operatorSourceDescription) delete(itName string, dr describerResrouce) {
-	dr.getIr(itName).remove(osrc.name, "opsrc", osrc.namespace)
-}
-
-func (osrc *operatorSourceDescription) getRunningNodes(oc *exutil.CLI) string {
-	nodesNames := getResource(oc, asAdmin, withoutNamespace, "pod", fmt.Sprintf("--selector=marketplace.operatorSource=%s", osrc.name), "-n", osrc.namespace, "-o=jsonpath={.items[*]..nodeName}")
-	o.Expect(nodesNames).NotTo(o.BeEmpty())
-	return nodesNames
-}
-func (osrc *operatorSourceDescription) getDeployment(oc *exutil.CLI) {
-	output := getResource(oc, asAdmin, withoutNamespace, "deployment", fmt.Sprintf("--selector=opsrc-owner-name=%s", osrc.name), "-n", osrc.namespace, "-o=jsonpath={.items[0].metadata.name}")
-	o.Expect(output).NotTo(o.BeEmpty())
-	osrc.deploymentName = output
-}
-func (osrc *operatorSourceDescription) patchDeployment(oc *exutil.CLI, content string) {
-	if strings.Compare(osrc.deploymentName, "") == 0 {
-		osrc.deploymentName = osrc.name
-	}
-	patchResource(oc, asAdmin, withoutNamespace, "deployment", osrc.deploymentName, "-n", osrc.namespace, "--type", "merge", "-p", content)
-}
-func (osrc *operatorSourceDescription) getTolerations(oc *exutil.CLI) string {
-	if strings.Compare(osrc.deploymentName, "") == 0 {
-		osrc.deploymentName = osrc.name
-	}
-	output := getResource(oc, asAdmin, withoutNamespace, "deployment", osrc.deploymentName, "-n", osrc.namespace, "-o=jsonpath={.spec.template.spec.tolerations}")
-	if strings.Compare(output, "") == 0 {
-		e2e.Logf("no tolerations %v", output)
-		return "\"tolerations\": null"
-	}
-	tolerations := "\"tolerations\": " + convertLMtoJSON(output)
-	e2e.Logf("the tolerations:===%v===", tolerations)
-	return tolerations
-}
-
-type catalogSourceConfigDescription struct {
-	name            string
-	namespace       string
-	packages        string
-	targetnamespace string
-	source          string
-	template        string
-}
-
-func (csc *catalogSourceConfigDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", csc.template, "-p", "NAME="+csc.name, "NAMESPACE="+csc.namespace,
-		"PACKAGES="+csc.packages, "TARGETNAMESPACE="+csc.targetnamespace, "SOURCE="+csc.source)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "csc", csc.name, requireNS, csc.namespace))
-}
-
-func (csc *catalogSourceConfigDescription) delete(itName string, dr describerResrouce) {
-	dr.getIr(itName).remove(csc.name, "csc", csc.namespace)
-}
-
-type projectDescription struct {
-	name            string
-	targetNamespace string
-}
-
-func (p *projectDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
-	removeResource(oc, asAdmin, withoutNamespace, "project", p.name)
-	_, err := doAction(oc, "new-project", asAdmin, withoutNamespace, p.name)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	dr.getIr(itName).add(newResource(oc, "project", p.name, notRequireNS, ""))
-	_, err = doAction(oc, "project", asAdmin, withoutNamespace, p.targetNamespace)
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-func (p *projectDescription) label(oc *exutil.CLI, label string) {
-	_, err := doAction(oc, "label", asAdmin, withoutNamespace, "ns", p.name, "env="+label)
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-func (p *projectDescription) delete(oc *exutil.CLI) {
-	_, err := doAction(oc, "delete", asAdmin, withoutNamespace, "project", p.name)
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-type serviceAccountDescription struct {
-	name           string
-	namespace      string
-	definitionfile string
-}
-
-func newSa(name, namespace string) *serviceAccountDescription {
-	return &serviceAccountDescription{
-		name:           name,
-		namespace:      namespace,
-		definitionfile: "",
-	}
-}
-func (sa *serviceAccountDescription) getDefinition(oc *exutil.CLI) {
-	parameters := []string{"sa", sa.name, "-n", sa.namespace, "-o=json"}
-	definitionfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(parameters...).OutputToFile("sa-config.json")
-	o.Expect(err).NotTo(o.HaveOccurred())
-	sa.definitionfile = definitionfile
-}
-func (sa *serviceAccountDescription) delete(oc *exutil.CLI) {
-	_, err := doAction(oc, "delete", asAdmin, withoutNamespace, "sa", sa.name, "-n", sa.namespace)
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-func (sa *serviceAccountDescription) reapply(oc *exutil.CLI) {
-	err := oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", sa.definitionfile).Execute()
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-func (sa *serviceAccountDescription) checkAuth(oc *exutil.CLI, expected string, cr string) {
-	err := wait.Poll(3*time.Second, 150*time.Second, func() (bool, error) {
-		output, _ := doAction(oc, "auth", asAdmin, withNamespace, "--as", fmt.Sprintf("system:serviceaccount:%s:%s", sa.namespace, sa.name), "can-i", "create", cr)
-		e2e.Logf("the result of checkAuth:%v", output)
-		if strings.Contains(output, expected) {
-			return true, nil
-		}
-		return false, nil
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-type roleDescription struct {
-	name      string
-	namespace string
-}
-
-func newRole(name string, namespace string) *roleDescription {
-	return &roleDescription{
-		name:      name,
-		namespace: namespace,
-	}
-}
-func (role *roleDescription) patch(oc *exutil.CLI, patch string) {
-	patchResource(oc, asAdmin, withoutNamespace, "role", role.name, "-n", role.namespace, "--type", "merge", "-p", patch)
-}
-func (role *roleDescription) getRules(oc *exutil.CLI) string {
-	return role.getRulesWithDelete(oc, "nodelete")
-}
-func (role *roleDescription) getRulesWithDelete(oc *exutil.CLI, delete string) string {
-	var roleboday map[string]interface{}
-	output := getResource(oc, asAdmin, withoutNamespace, "role", role.name, "-n", role.namespace, "-o=json")
-	err := json.Unmarshal([]byte(output), &roleboday)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	rules := roleboday["rules"].([]interface{})
-
-	handleRuleAttribute := func(rc *strings.Builder, rt string, r map[string]interface{}) {
-		rc.WriteString("\"" + rt + "\":[")
-		items := r[rt].([]interface{})
-		e2e.Logf("%s:%v, and the len:%v", rt, items, len(items))
-		for i, v := range items {
-			vc := v.(string)
-			rc.WriteString("\"" + vc + "\"")
-			if i != len(items)-1 {
-				rc.WriteString(",")
-			}
-		}
-		rc.WriteString("]")
-		if strings.Compare(rt, "verbs") != 0 {
-			rc.WriteString(",")
-		}
-	}
-
-	var rc strings.Builder
-	rc.WriteString("[")
-	for _, rv := range rules {
-		rule := rv.(map[string]interface{})
-		if strings.Compare(delete, "nodelete") != 0 && strings.Compare(rule["apiGroups"].([]interface{})[0].(string), delete) == 0 {
-			continue
-		}
-
-		rc.WriteString("{")
-		handleRuleAttribute(&rc, "apiGroups", rule)
-		handleRuleAttribute(&rc, "resources", rule)
-		handleRuleAttribute(&rc, "verbs", rule)
-		rc.WriteString("},")
-	}
-	result := strings.TrimSuffix(rc.String(), ",") + "]"
-	e2e.Logf("rc:%v", result)
-	return result
-}
-
-type checkDescription struct {
-	method          string
-	executor        bool
-	inlineNamespace bool
-	expectAction    bool
-	expectContent   string
-	expect          bool
-	resource        []string
-}
-
-func newCheck(method string, executor bool, inlineNamespace bool, expectAction bool,
-	expectContent string, expect bool, resource []string) checkDescription {
-	return checkDescription{
-		method:          method,
-		executor:        executor,
-		inlineNamespace: inlineNamespace,
-		expectAction:    expectAction,
-		expectContent:   expectContent,
-		expect:          expect,
-		resource:        resource,
-	}
-}
-func (ck checkDescription) check(oc *exutil.CLI) {
-	switch ck.method {
-	case "present":
-		ok := isPresentResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.resource...)
-		o.Expect(ok).To(o.BeTrue())
-	case "expect":
-		err := expectedResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.expectContent, ck.expect, ck.resource...)
-		o.Expect(err).NotTo(o.HaveOccurred())
-	default:
-		err := fmt.Errorf("unknown method")
-		o.Expect(err).NotTo(o.HaveOccurred())
-	}
-}
-func (ck checkDescription) checkWithoutAssert(oc *exutil.CLI) error {
-	switch ck.method {
-	case "present":
-		ok := isPresentResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.resource...)
-		if ok {
-			return nil
-		}
-		return fmt.Errorf("it is not epxected")
-	case "expect":
-		return expectedResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.expectContent, ck.expect, ck.resource...)
-	default:
-		return fmt.Errorf("unknown method")
-	}
-}
-
-type checkList []checkDescription
-
-func (cl checkList) add(ck checkDescription) {
-	cl = append(cl, ck)
-}
-func (cl checkList) empty() {
-	cl = cl[0:0]
-}
-func (cl checkList) check(oc *exutil.CLI) {
-	var wg sync.WaitGroup
-	for _, ck := range cl {
-		wg.Add(1)
-		go func(ck checkDescription) {
-			defer g.GinkgoRecover()
-			defer wg.Done()
-			ck.check(oc)
-		}(ck)
-	}
-	wg.Wait()
-}
-
-type resourceDescription struct {
-	oc               *exutil.CLI
-	asAdmin          bool
-	withoutNamespace bool
-	kind             string
-	name             string
-	requireNS        bool
-	namespace        string
-}
-
-func newResource(oc *exutil.CLI, kind string, name string, nsflag bool, namespace string) resourceDescription {
-	return resourceDescription{
-		oc:               oc,
-		asAdmin:          asAdmin,
-		withoutNamespace: withoutNamespace,
-		kind:             kind,
-		name:             name,
-		requireNS:        nsflag,
-		namespace:        namespace,
-	}
-}
-func (r resourceDescription) delete() {
-	if r.withoutNamespace && r.requireNS {
-		removeResource(r.oc, r.asAdmin, r.withoutNamespace, r.kind, r.name, "-n", r.namespace)
-	} else {
-		removeResource(r.oc, r.asAdmin, r.withoutNamespace, r.kind, r.name)
-	}
-}
-
-type itResource map[string]resourceDescription
-
-func (ir itResource) add(r resourceDescription) {
-	ir[r.name+r.kind+r.namespace] = r
-}
-func (ir itResource) get(name string, kind string, namespace string) resourceDescription {
-	r, ok := ir[name+kind+namespace]
-	o.Expect(ok).To(o.BeTrue())
-	return r
-}
-func (ir itResource) remove(name string, kind string, namespace string) {
-	rKey := name + kind + namespace
-	if r, ok := ir[rKey]; ok {
-		r.delete()
-		delete(ir, rKey)
-	}
-}
-func (ir itResource) cleanup() {
-	for _, r := range ir {
-		e2e.Logf("cleanup resource %s,   %s", r.kind, r.name)
-		ir.remove(r.name, r.kind, r.namespace)
-	}
-}
-
-type describerResrouce map[string]itResource
-
-func (dr describerResrouce) addIr(itName string) {
-	dr[itName] = itResource{}
-}
-func (dr describerResrouce) getIr(itName string) itResource {
-	ir, ok := dr[itName]
-	o.Expect(ok).To(o.BeTrue())
-	return ir
-}
-func (dr describerResrouce) rmIr(itName string) {
-	delete(dr, itName)
-}
-
-func convertLMtoJSON(content string) string {
-	var jb strings.Builder
-	jb.WriteString("[")
-	items := strings.Split(strings.TrimSuffix(strings.TrimPrefix(content, "["), "]"), "map")
-	for _, item := range items {
-		if strings.Compare(item, "") == 0 {
-			continue
-		}
-		kvs := strings.Fields(strings.TrimSuffix(strings.TrimPrefix(item, "["), "]"))
-		jb.WriteString("{")
-		for ki, kv := range kvs {
-			p := strings.Split(kv, ":")
-			jb.WriteString("\"" + p[0] + "\":")
-			jb.WriteString("\"" + p[1] + "\"")
-			if ki < len(kvs)-1 {
-				jb.WriteString(", ")
-			}
-		}
-		jb.WriteString("},")
-	}
-	return strings.TrimSuffix(jb.String(), ",") + "]"
-}
-
-func getRandomString() string {
-	chars := "abcdefghijklmnopqrstuvwxyz0123456789"
-	seed := rand.New(rand.NewSource(time.Now().UnixNano()))
-	buffer := make([]byte, 8)
-	for index := range buffer {
-		buffer[index] = chars[seed.Intn(len(chars))]
-	}
-	return string(buffer)
-}
-
-func generateUpdatedKubernatesVersion(oc *exutil.CLI) string {
-	subKubeVersions := strings.Split(getKubernetesVersion(oc), ".")
-	zVersion, _ := strconv.Atoi(subKubeVersions[1])
-	subKubeVersions[1] = strconv.Itoa(zVersion + 1)
-	return strings.Join(subKubeVersions[0:2], ".") + ".0"
-}
-
-func getKubernetesVersion(oc *exutil.CLI) string {
-	output, err := doAction(oc, "version", asAdmin, withoutNamespace, "-o=json")
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	var result map[string]interface{}
-	err = json.Unmarshal([]byte(output), &result)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	gitVersion := result["serverVersion"].(map[string]interface{})["gitVersion"]
-	e2e.Logf("gitVersion is %v", gitVersion)
-	return strings.TrimPrefix(gitVersion.(string), "v")
-}
-
-func applyResourceFromTemplate(oc *exutil.CLI, parameters ...string) error {
-	var configFile string
-	err := wait.Poll(3*time.Second, 15*time.Second, func() (bool, error) {
-		output, err := oc.AsAdmin().Run("process").Args(parameters...).OutputToFile(getRandomString() + "olm-config.json")
-		if err != nil {
-			e2e.Logf("the err:%v, and try next round", err)
-			return false, nil
-		}
-		configFile = output
-		return true, nil
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	e2e.Logf("the file of resource is %s", configFile)
-	return oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", configFile).Execute()
-}
-
-func isPresentResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, present bool, parameters ...string) bool {
-	parameters = append(parameters, "--ignore-not-found")
-	err := wait.Poll(3*time.Second, 60*time.Second, func() (bool, error) {
-		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
-		if err != nil {
-			e2e.Logf("the get error is %v, and try next", err)
-			return false, nil
-		}
-		if !present && strings.Compare(output, "") == 0 {
-			return true, nil
-		}
-		if present && strings.Compare(output, "") != 0 {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		return false
-	}
-	return true
-}
-
-func patchResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) {
-	_, err := doAction(oc, "patch", asAdmin, withoutNamespace, parameters...)
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-func execResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) string {
-	var result string
-	err := wait.Poll(3*time.Second, 6*time.Second, func() (bool, error) {
-		output, err := doAction(oc, "exec", asAdmin, withoutNamespace, parameters...)
-		if err != nil {
-			e2e.Logf("the exec error is %v, and try next", err)
-			return false, nil
-		}
-		result = output
-		return true, nil
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	e2e.Logf("the result of exec resource:%v", result)
-	return result
-}
-
-func getResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) string {
-	var result string
-	err := wait.Poll(3*time.Second, 120*time.Second, func() (bool, error) {
-		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
-		if err != nil {
-			e2e.Logf("the get error is %v, and try next", err)
-			return false, nil
-		}
-		result = output
-		return true, nil
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	e2e.Logf("the result of queried resource:%v", result)
-	return result
-}
-
-func expectedResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, isCompare bool, content string, expect bool, parameters ...string) error {
-	cc := func(a, b string, ic bool) bool {
-		bs := strings.Split(b, "+2+")
-		ret := false
-		for _, s := range bs {
-			if (ic && strings.Compare(a, s) == 0) || (!ic && strings.Contains(a, s)) {
-				ret = true
-			}
-		}
-		return ret
-	}
-	return wait.Poll(3*time.Second, 150*time.Second, func() (bool, error) {
-		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
-		if err != nil {
-			e2e.Logf("the get error is %v, and try next", err)
-			return false, nil
-		}
-		e2e.Logf("the queried resource:%s", output)
-		if isCompare && expect && cc(output, content, isCompare) {
-			e2e.Logf("the output %s matches one of the content %s, expected", output, content)
-			return true, nil
-		}
-		if isCompare && !expect && !cc(output, content, isCompare) {
-			e2e.Logf("the output %s does not matche the content %s, expected", output, content)
-			return true, nil
-		}
-		if !isCompare && expect && cc(output, content, isCompare) {
-			e2e.Logf("the output %s contains one of the content %s, expected", output, content)
-			return true, nil
-		}
-		if !isCompare && !expect && !cc(output, content, isCompare) {
-			e2e.Logf("the output %s does not contain the content %s, expected", output, content)
-			return true, nil
-		}
-		return false, nil
-	})
-}
-
-func removeResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) {
-	output, err := doAction(oc, "delete", asAdmin, withoutNamespace, parameters...)
-	if err != nil && (strings.Contains(output, "NotFound") || strings.Contains(output, "No resources found")) {
-		e2e.Logf("the resource is deleted already")
-		return
-	}
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	err = wait.Poll(3*time.Second, 120*time.Second, func() (bool, error) {
-		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
-		if err != nil && (strings.Contains(output, "NotFound") || strings.Contains(output, "No resources found")) {
-			e2e.Logf("the resource is delete successfully")
-			return true, nil
-		}
-		return false, nil
-	})
-	o.Expect(err).NotTo(o.HaveOccurred())
-}
-
-func doAction(oc *exutil.CLI, action string, asAdmin bool, withoutNamespace bool, parameters ...string) (string, error) {
-	if asAdmin && withoutNamespace {
-		return oc.AsAdmin().WithoutNamespace().Run(action).Args(parameters...).Output()
-	}
-	if asAdmin && !withoutNamespace {
-		return oc.AsAdmin().Run(action).Args(parameters...).Output()
-	}
-	if !asAdmin && withoutNamespace {
-		return oc.WithoutNamespace().Run(action).Args(parameters...).Output()
-	}
-	if !asAdmin && !withoutNamespace {
-		return oc.Run(action).Args(parameters...).Output()
-	}
-	return "", nil
-}

--- a/test/extended/operators/olm_utils.go
+++ b/test/extended/operators/olm_utils.go
@@ -1,0 +1,958 @@
+package operators
+
+import (
+	"encoding/json"
+	"fmt"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+
+	"io/ioutil"
+	"math/rand"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	exutil "github.com/openshift/openshift-tests/test/extended/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	asAdmin          = true
+	asUser           = false
+	withoutNamespace = true
+	withNamespace    = false
+	compare          = true
+	contain          = false
+	requireNS        = true
+	notRequireNS     = false
+	present          = true
+	notPresent       = false
+	ok               = true
+	nok              = false
+)
+
+type csvDescription struct {
+	name      string
+	namespace string
+}
+
+// the method is to delete csv.
+func (csv csvDescription) delete(itName string, dr describerResrouce) {
+	dr.getIr(itName).remove(csv.name, "csv", csv.namespace)
+}
+
+type subscriptionDescription struct {
+	subName                string `json:"name"`
+	namespace              string `json:"namespace"`
+	channel                string `json:"channel"`
+	ipApproval             string `json:"installPlanApproval"`
+	operatorPackage        string `json:"spec.name"`
+	catalogSourceName      string `json:"source"`
+	catalogSourceNamespace string `json:"sourceNamespace"`
+	startingCSV            string `json:"startingCSV,omitempty"`
+	currentCSV             string
+	installedCSV           string
+	template               string
+	singleNamespace        bool
+	ipCsv                  string
+}
+
+//the method is to create sub, and save the sub resrouce into dr. and more create csv possible depending on sub.ipApproval
+//if sub.ipApproval is Automatic, it will wait the sub's state become AtLatestKnown and get installed csv as sub.installedCSV, and save csv into dr
+//if sub.ipApproval is not Automatic, it will just wait sub's state become UpgradePending
+func (sub *subscriptionDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	sub.createWithoutCheck(oc, itName, dr)
+	if strings.Compare(sub.ipApproval, "Automatic") == 0 {
+		sub.findInstalledCSV(oc, itName, dr)
+	} else {
+		newCheck("expect", asAdmin, withoutNamespace, compare, "UpgradePending", ok, []string{"sub", sub.subName, "-n", sub.namespace, "-o=jsonpath={.status.state}"}).check(oc)
+	}
+}
+
+//the method is to just create sub, and save it to dr, do not check its state.
+func (sub *subscriptionDescription) createWithoutCheck(oc *exutil.CLI, itName string, dr describerResrouce) {
+	//isAutomatic := strings.Compare(sub.ipApproval, "Automatic") == 0
+
+	//startingCSV is not necessary. And, if there are multi same package from different CatalogSource, it will lead to error.
+	//if strings.Compare(sub.currentCSV, "") == 0 {
+	//	sub.currentCSV = getResource(oc, asAdmin, withoutNamespace, "packagemanifest", sub.operatorPackage, fmt.Sprintf("-o=jsonpath={.status.channels[?(@.name==\"%s\")].currentCSV}", sub.channel))
+	//	o.Expect(sub.currentCSV).NotTo(o.BeEmpty())
+	//}
+
+	//if isAutomatic {
+	//	sub.startingCSV = sub.currentCSV
+	//} else {
+	//	o.Expect(sub.startingCSV).NotTo(o.BeEmpty())
+	//}
+
+	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", sub.template, "-p", "SUBNAME="+sub.subName, "SUBNAMESPACE="+sub.namespace, "CHANNEL="+sub.channel,
+		"APPROVAL="+sub.ipApproval, "OPERATORNAME="+sub.operatorPackage, "SOURCENAME="+sub.catalogSourceName, "SOURCENAMESPACE="+sub.catalogSourceNamespace, "STARTINGCSV="+sub.startingCSV)
+
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "sub", sub.subName, requireNS, sub.namespace))
+}
+
+//the method is to check if the sub's state is AtLatestKnown.
+//if it is AtLatestKnown, get installed csv from sub and save it to dr.
+//if it is not AtLatestKnown, raise error.
+func (sub *subscriptionDescription) findInstalledCSV(oc *exutil.CLI, itName string, dr describerResrouce) {
+	newCheck("expect", asAdmin, withoutNamespace, compare, "AtLatestKnown", ok, []string{"sub", sub.subName, "-n", sub.namespace, "-o=jsonpath={.status.state}"}).check(oc)
+	installedCSV := getResource(oc, asAdmin, withoutNamespace, "sub", sub.subName, "-n", sub.namespace, "-o=jsonpath={.status.installedCSV}")
+	o.Expect(installedCSV).NotTo(o.BeEmpty())
+	if strings.Compare(sub.installedCSV, installedCSV) != 0 {
+		sub.installedCSV = installedCSV
+		dr.getIr(itName).add(newResource(oc, "csv", sub.installedCSV, requireNS, sub.namespace))
+	}
+	e2e.Logf("the installed CSV name is %s", sub.installedCSV)
+}
+
+//the method is to check if the cv parameter is same to the installed csv.
+//if not same, raise error.
+//if same, nothong happen.
+func (sub *subscriptionDescription) expectCSV(oc *exutil.CLI, itName string, dr describerResrouce, cv string) {
+	err := wait.Poll(3*time.Second, 180*time.Second, func() (bool, error) {
+		sub.findInstalledCSV(oc, itName, dr)
+		if strings.Compare(sub.installedCSV, cv) == 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to approve the install plan when you create sub with sub.ipApproval != Automatic
+//normally firstly call sub.create(), then call this method sub.approve. it is used to operator upgrade case.
+func (sub *subscriptionDescription) approve(oc *exutil.CLI, itName string, dr describerResrouce) {
+	err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
+		for strings.Compare(sub.installedCSV, "") == 0 {
+			state := getResource(oc, asAdmin, withoutNamespace, "sub", sub.subName, "-n", sub.namespace, "-o=jsonpath={.status.state}")
+			if strings.Compare(state, "AtLatestKnown") == 0 {
+				sub.installedCSV = getResource(oc, asAdmin, withoutNamespace, "sub", sub.subName, "-n", sub.namespace, "-o=jsonpath={.status.installedCSV}")
+				dr.getIr(itName).add(newResource(oc, "csv", sub.installedCSV, requireNS, sub.namespace))
+				e2e.Logf("it is already done, and the installed CSV name is %s", sub.installedCSV)
+				continue
+			}
+
+			ipCsv := getResource(oc, asAdmin, withoutNamespace, "sub", sub.subName, "-n", sub.namespace, "-o=jsonpath={.status.installplan.name}{\" \"}{.status.currentCSV}")
+			sub.ipCsv = ipCsv + "##" + sub.ipCsv
+			installPlan := strings.Fields(ipCsv)[0]
+			o.Expect(installPlan).NotTo(o.BeEmpty())
+			e2e.Logf("try to approve installPlan %s", installPlan)
+			patchResource(oc, asAdmin, withoutNamespace, "ip", installPlan, "-n", sub.namespace, "--type", "merge", "-p", "{\"spec\": {\"approved\": true}}")
+			err := wait.Poll(3*time.Second, 10*time.Second, func() (bool, error) {
+				err := newCheck("expect", asAdmin, withoutNamespace, compare, "Complete", ok, []string{"ip", installPlan, "-n", sub.namespace, "-o=jsonpath={.status.phase}"}).checkWithoutAssert(oc)
+				if err != nil {
+					e2e.Logf("the get error is %v, and try next", err)
+					return false, nil
+				}
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to construct one csv object.
+func (sub *subscriptionDescription) getCSV() csvDescription {
+	return csvDescription{sub.installedCSV, sub.namespace}
+}
+
+//the method is to get the CR version from alm-examples of csv if it exists
+func (sub *subscriptionDescription) getInstanceVersion(oc *exutil.CLI) string {
+	version := ""
+	output := strings.Split(getResource(oc, asUser, withoutNamespace, "csv", sub.installedCSV, "-n", sub.namespace, "-o=jsonpath={.metadata.annotations.alm-examples}"), "\n")
+	for _, line := range output {
+		if strings.Contains(line, "\"version\"") {
+			version = strings.Trim(strings.Fields(strings.TrimSpace(line))[1], "\"")
+			break
+		}
+	}
+	o.Expect(version).NotTo(o.BeEmpty())
+	return version
+}
+
+//the method is obsolete
+func (sub *subscriptionDescription) createInstance(oc *exutil.CLI, instance string) {
+	path := filepath.Join(e2e.TestContext.OutputDir, sub.namespace+"-"+"instance.json")
+	err := ioutil.WriteFile(path, []byte(instance), 0644)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-n", sub.namespace, "-f", path).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to delete sub which is saved when calling sub.create() or sub.createWithoutCheck()
+func (sub *subscriptionDescription) delete(itName string, dr describerResrouce) {
+	dr.getIr(itName).remove(sub.subName, "sub", sub.namespace)
+}
+
+//the method is to patch sub object
+func (sub *subscriptionDescription) patch(oc *exutil.CLI, patch string) {
+	patchResource(oc, asAdmin, withoutNamespace, "sub", sub.subName, "-n", sub.namespace, "--type", "merge", "-p", patch)
+}
+
+type crdDescription struct {
+	name     string
+	template string
+}
+
+//the method is to create CRD with template and save it to dr.
+func (crd *crdDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", crd.template, "-p", "NAME="+crd.name)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "crd", crd.name, notRequireNS, ""))
+}
+
+//the method is to delete CRD.
+func (crd *crdDescription) delete(oc *exutil.CLI) {
+	removeResource(oc, asAdmin, withoutNamespace, "crd", crd.name)
+}
+
+type configMapDescription struct {
+	name      string
+	namespace string
+	template  string
+}
+
+//the method is to create cm with template and save it to dr
+func (cm *configMapDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", cm.template, "-p", "NAME="+cm.name, "NAMESPACE="+cm.namespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "cm", cm.name, requireNS, cm.namespace))
+}
+
+//the method is to patch cm.
+func (cm *configMapDescription) patch(oc *exutil.CLI, patch string) {
+	patchResource(oc, asAdmin, withoutNamespace, "cm", cm.name, "-n", cm.namespace, "--type", "merge", "-p", patch)
+}
+
+type catalogSourceDescription struct {
+	name        string
+	namespace   string
+	displayName string
+	publisher   string
+	sourceType  string
+	address     string
+	template    string
+	priority    int
+}
+
+//the method is to create catalogsource with template, and save it to dr.
+func (catsrc *catalogSourceDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", catsrc.template,
+		"-p", "NAME="+catsrc.name, "NAMESPACE="+catsrc.namespace, "ADDRESS="+catsrc.address,
+		"DISPLAYNAME="+"\""+catsrc.displayName+"\"", "PUBLISHER="+"\""+catsrc.publisher+"\"", "SOURCETYPE="+catsrc.sourceType)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "catsrc", catsrc.name, requireNS, catsrc.namespace))
+}
+
+//the method is to delete catalogsource.
+func (catsrc *catalogSourceDescription) delete(itName string, dr describerResrouce) {
+	dr.getIr(itName).remove(catsrc.name, "catsrc", catsrc.namespace)
+}
+
+type customResourceDescription struct {
+	name      string
+	namespace string
+	typename  string
+	template  string
+}
+
+//the method is to create CR with template, and save it to dr.
+func (crinstance *customResourceDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", crinstance.template,
+		"-p", "NAME="+crinstance.name, "NAMESPACE="+crinstance.namespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, crinstance.typename, crinstance.name, requireNS, crinstance.namespace))
+}
+
+//the method is to delete CR
+func (crinstance *customResourceDescription) delete(itName string, dr describerResrouce) {
+	dr.getIr(itName).remove(crinstance.name, crinstance.typename, crinstance.namespace)
+}
+
+type operatorGroupDescription struct {
+	name         string
+	namespace    string
+	multinslabel string
+	template     string
+}
+
+//the method is to check if og exist. if not existing, create it with template and save it to dr.
+//if existing, nothing happen.
+func (og *operatorGroupDescription) createwithCheck(oc *exutil.CLI, itName string, dr describerResrouce) {
+	output, err := doAction(oc, "get", asAdmin, false, "operatorgroup")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if strings.Contains(output, "No resources found") {
+		e2e.Logf(fmt.Sprintf("No operatorgroup in project: %s, create one: %s", oc.Namespace, og.name))
+		og.create(oc, itName, dr)
+	} else {
+		e2e.Logf(fmt.Sprintf("Already exist operatorgroup in project: %s", oc.Namespace))
+	}
+
+}
+
+//the method is to create og and save it to dr
+//if og.multinslabel is not set, it will create og with ownnamespace or allnamespace depending on template
+//if og.multinslabel is set, it will create og with multinamespace.
+func (og *operatorGroupDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	var err error
+	if strings.Compare(og.multinslabel, "") == 0 {
+		err = applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", og.template, "-p", "NAME="+og.name, "NAMESPACE="+og.namespace)
+	} else {
+		err = applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", og.template, "-p", "NAME="+og.name, "NAMESPACE="+og.namespace, "MULTINSLABEL="+og.multinslabel)
+	}
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "og", og.name, requireNS, og.namespace))
+}
+
+//the method is to delete og
+func (og *operatorGroupDescription) delete(itName string, dr describerResrouce) {
+	dr.getIr(itName).remove(og.name, "og", og.namespace)
+}
+
+//the struct and its method are obsolete because no operatorSource anymore.
+type operatorSourceDescription struct {
+	name              string
+	namespace         string
+	namelabel         string
+	registrynamespace string
+	displayname       string
+	publisher         string
+	template          string
+	deploymentName    string
+}
+
+func (osrc *operatorSourceDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", osrc.template, "-p", "NAME="+osrc.name, "NAMESPACE="+osrc.namespace,
+		"NAMELABEL="+osrc.namelabel, "REGISTRYNAMESPACE="+osrc.registrynamespace, "DISPLAYNAME="+osrc.displayname, "PUBLISHER="+osrc.publisher)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "opsrc", osrc.name, requireNS, osrc.namespace))
+}
+
+func (osrc *operatorSourceDescription) delete(itName string, dr describerResrouce) {
+	dr.getIr(itName).remove(osrc.name, "opsrc", osrc.namespace)
+}
+
+func (osrc *operatorSourceDescription) getRunningNodes(oc *exutil.CLI) string {
+	nodesNames := getResource(oc, asAdmin, withoutNamespace, "pod", fmt.Sprintf("--selector=marketplace.operatorSource=%s", osrc.name), "-n", osrc.namespace, "-o=jsonpath={.items[*]..nodeName}")
+	o.Expect(nodesNames).NotTo(o.BeEmpty())
+	return nodesNames
+}
+func (osrc *operatorSourceDescription) getDeployment(oc *exutil.CLI) {
+	output := getResource(oc, asAdmin, withoutNamespace, "deployment", fmt.Sprintf("--selector=opsrc-owner-name=%s", osrc.name), "-n", osrc.namespace, "-o=jsonpath={.items[0].metadata.name}")
+	o.Expect(output).NotTo(o.BeEmpty())
+	osrc.deploymentName = output
+}
+func (osrc *operatorSourceDescription) patchDeployment(oc *exutil.CLI, content string) {
+	if strings.Compare(osrc.deploymentName, "") == 0 {
+		osrc.deploymentName = osrc.name
+	}
+	patchResource(oc, asAdmin, withoutNamespace, "deployment", osrc.deploymentName, "-n", osrc.namespace, "--type", "merge", "-p", content)
+}
+func (osrc *operatorSourceDescription) getTolerations(oc *exutil.CLI) string {
+	if strings.Compare(osrc.deploymentName, "") == 0 {
+		osrc.deploymentName = osrc.name
+	}
+	output := getResource(oc, asAdmin, withoutNamespace, "deployment", osrc.deploymentName, "-n", osrc.namespace, "-o=jsonpath={.spec.template.spec.tolerations}")
+	if strings.Compare(output, "") == 0 {
+		e2e.Logf("no tolerations %v", output)
+		return "\"tolerations\": null"
+	}
+	tolerations := "\"tolerations\": " + convertLMtoJSON(output)
+	e2e.Logf("the tolerations:===%v===", tolerations)
+	return tolerations
+}
+
+////the struct and its method are obsolete because no csc anymore.
+type catalogSourceConfigDescription struct {
+	name            string
+	namespace       string
+	packages        string
+	targetnamespace string
+	source          string
+	template        string
+}
+
+func (csc *catalogSourceConfigDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	err := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", csc.template, "-p", "NAME="+csc.name, "NAMESPACE="+csc.namespace,
+		"PACKAGES="+csc.packages, "TARGETNAMESPACE="+csc.targetnamespace, "SOURCE="+csc.source)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "csc", csc.name, requireNS, csc.namespace))
+}
+
+func (csc *catalogSourceConfigDescription) delete(itName string, dr describerResrouce) {
+	dr.getIr(itName).remove(csc.name, "csc", csc.namespace)
+}
+
+type projectDescription struct {
+	name            string
+	targetNamespace string
+}
+
+//the method is to check if the project exists. if not, create it with name, and go to it.
+//if existing, nothing happen.
+func (p *projectDescription) createwithCheck(oc *exutil.CLI, itName string, dr describerResrouce) {
+	output, err := doAction(oc, "get", asAdmin, withoutNamespace, "project", p.name)
+	if err != nil {
+		e2e.Logf(fmt.Sprintf("Output: %s, cannot find the %s project, create one", output, p.name))
+		_, err := doAction(oc, "adm", asAdmin, withoutNamespace, "new-project", p.name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		dr.getIr(itName).add(newResource(oc, "project", p.name, notRequireNS, ""))
+		_, err = doAction(oc, "project", asAdmin, withoutNamespace, p.name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+	} else {
+		e2e.Logf(fmt.Sprintf("project: %s already exist!", p.name))
+	}
+}
+
+//the method is to delete project with name if exist. and then create it with name, and back to project with targetNamespace
+func (p *projectDescription) create(oc *exutil.CLI, itName string, dr describerResrouce) {
+	removeResource(oc, asAdmin, withoutNamespace, "project", p.name)
+	_, err := doAction(oc, "new-project", asAdmin, withoutNamespace, p.name)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	dr.getIr(itName).add(newResource(oc, "project", p.name, notRequireNS, ""))
+	_, err = doAction(oc, "project", asAdmin, withoutNamespace, p.targetNamespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to label project
+func (p *projectDescription) label(oc *exutil.CLI, label string) {
+	_, err := doAction(oc, "label", asAdmin, withoutNamespace, "ns", p.name, "env="+label)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to delete project
+func (p *projectDescription) delete(oc *exutil.CLI) {
+	_, err := doAction(oc, "delete", asAdmin, withoutNamespace, "project", p.name)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+type serviceAccountDescription struct {
+	name           string
+	namespace      string
+	definitionfile string
+}
+
+//the method is to construct one sa.
+func newSa(name, namespace string) *serviceAccountDescription {
+	return &serviceAccountDescription{
+		name:           name,
+		namespace:      namespace,
+		definitionfile: "",
+	}
+}
+
+//the method is to get sa definition.
+func (sa *serviceAccountDescription) getDefinition(oc *exutil.CLI) {
+	parameters := []string{"sa", sa.name, "-n", sa.namespace, "-o=json"}
+	definitionfile, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(parameters...).OutputToFile("sa-config.json")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	sa.definitionfile = definitionfile
+}
+
+//the method is to delete sa
+func (sa *serviceAccountDescription) delete(oc *exutil.CLI) {
+	_, err := doAction(oc, "delete", asAdmin, withoutNamespace, "sa", sa.name, "-n", sa.namespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to apply sa with its member definitionfile
+func (sa *serviceAccountDescription) reapply(oc *exutil.CLI) {
+	err := oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", sa.definitionfile).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to check if what sa can do is expected with expected paramter.
+func (sa *serviceAccountDescription) checkAuth(oc *exutil.CLI, expected string, cr string) {
+	err := wait.Poll(3*time.Second, 150*time.Second, func() (bool, error) {
+		output, _ := doAction(oc, "auth", asAdmin, withNamespace, "--as", fmt.Sprintf("system:serviceaccount:%s:%s", sa.namespace, sa.name), "can-i", "create", cr)
+		e2e.Logf("the result of checkAuth:%v", output)
+		if strings.Contains(output, expected) {
+			return true, nil
+		}
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+type roleDescription struct {
+	name      string
+	namespace string
+}
+
+//the method is to construct one Role object.
+func newRole(name string, namespace string) *roleDescription {
+	return &roleDescription{
+		name:      name,
+		namespace: namespace,
+	}
+}
+
+//the method is to patch Role object.
+func (role *roleDescription) patch(oc *exutil.CLI, patch string) {
+	patchResource(oc, asAdmin, withoutNamespace, "role", role.name, "-n", role.namespace, "--type", "merge", "-p", patch)
+}
+
+//the method is to get rules from Role object.
+func (role *roleDescription) getRules(oc *exutil.CLI) string {
+	return role.getRulesWithDelete(oc, "nodelete")
+}
+
+//the method is to get new rule without delete parameter based on current role.
+func (role *roleDescription) getRulesWithDelete(oc *exutil.CLI, delete string) string {
+	var roleboday map[string]interface{}
+	output := getResource(oc, asAdmin, withoutNamespace, "role", role.name, "-n", role.namespace, "-o=json")
+	err := json.Unmarshal([]byte(output), &roleboday)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	rules := roleboday["rules"].([]interface{})
+
+	handleRuleAttribute := func(rc *strings.Builder, rt string, r map[string]interface{}) {
+		rc.WriteString("\"" + rt + "\":[")
+		items := r[rt].([]interface{})
+		e2e.Logf("%s:%v, and the len:%v", rt, items, len(items))
+		for i, v := range items {
+			vc := v.(string)
+			rc.WriteString("\"" + vc + "\"")
+			if i != len(items)-1 {
+				rc.WriteString(",")
+			}
+		}
+		rc.WriteString("]")
+		if strings.Compare(rt, "verbs") != 0 {
+			rc.WriteString(",")
+		}
+	}
+
+	var rc strings.Builder
+	rc.WriteString("[")
+	for _, rv := range rules {
+		rule := rv.(map[string]interface{})
+		if strings.Compare(delete, "nodelete") != 0 && strings.Compare(rule["apiGroups"].([]interface{})[0].(string), delete) == 0 {
+			continue
+		}
+
+		rc.WriteString("{")
+		handleRuleAttribute(&rc, "apiGroups", rule)
+		handleRuleAttribute(&rc, "resources", rule)
+		handleRuleAttribute(&rc, "verbs", rule)
+		rc.WriteString("},")
+	}
+	result := strings.TrimSuffix(rc.String(), ",") + "]"
+	e2e.Logf("rc:%v", result)
+	return result
+}
+
+type checkDescription struct {
+	method          string
+	executor        bool
+	inlineNamespace bool
+	expectAction    bool
+	expectContent   string
+	expect          bool
+	resource        []string
+}
+
+//the method is to make newCheck object.
+//the method paramter is expect, it will check something is expceted or not
+//the method paramter is present, it will check something exists or not
+//the executor is asAdmin, it will exectue oc with Admin
+//the executor is asUser, it will exectue oc with User
+//the inlineNamespace is withoutNamespace, it will execute oc with WithoutNamespace()
+//the inlineNamespace is withNamespace, it will execute oc with WithNamespace()
+//the expectAction take effective when method is expect, if it is contain, it will check if the strings contain substring with expectContent parameter
+//                                                       if it is compare, it will check the strings is samme with expectContent parameter
+//the expectContent is the content we expected
+//the expect is ok, contain or compare result is OK for method == expect, no error raise. if not OK, error raise
+//the expect is nok, contain or compare result is NOK for method == expect, no error raise. if OK, error raise
+//the expect is ok, resource existing is OK for method == present, no error raise. if resource not existing, error raise
+//the expect is nok, resource not existing is OK for method == present, no error raise. if resource existing, error raise
+func newCheck(method string, executor bool, inlineNamespace bool, expectAction bool,
+	expectContent string, expect bool, resource []string) checkDescription {
+	return checkDescription{
+		method:          method,
+		executor:        executor,
+		inlineNamespace: inlineNamespace,
+		expectAction:    expectAction,
+		expectContent:   expectContent,
+		expect:          expect,
+		resource:        resource,
+	}
+}
+
+//the method is to check the resource per definition of the above described newCheck.
+func (ck checkDescription) check(oc *exutil.CLI) {
+	switch ck.method {
+	case "present":
+		ok := isPresentResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.resource...)
+		o.Expect(ok).To(o.BeTrue())
+	case "expect":
+		err := expectedResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.expectContent, ck.expect, ck.resource...)
+		o.Expect(err).NotTo(o.HaveOccurred())
+	default:
+		err := fmt.Errorf("unknown method")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+}
+
+//the method is to check the resource, but not assert it which is diffrence with the method check().
+func (ck checkDescription) checkWithoutAssert(oc *exutil.CLI) error {
+	switch ck.method {
+	case "present":
+		ok := isPresentResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.resource...)
+		if ok {
+			return nil
+		}
+		return fmt.Errorf("it is not epxected")
+	case "expect":
+		return expectedResource(oc, ck.executor, ck.inlineNamespace, ck.expectAction, ck.expectContent, ck.expect, ck.resource...)
+	default:
+		return fmt.Errorf("unknown method")
+	}
+}
+
+//it is the check list so that all the check are done in parallel.
+type checkList []checkDescription
+
+//the method is to add one check
+func (cl checkList) add(ck checkDescription) {
+	cl = append(cl, ck)
+}
+
+//the method is to make check list empty.
+func (cl checkList) empty() {
+	cl = cl[0:0]
+}
+
+//the method is to execute all the check in parallel.
+func (cl checkList) check(oc *exutil.CLI) {
+	var wg sync.WaitGroup
+	for _, ck := range cl {
+		wg.Add(1)
+		go func(ck checkDescription) {
+			defer g.GinkgoRecover()
+			defer wg.Done()
+			ck.check(oc)
+		}(ck)
+	}
+	wg.Wait()
+}
+
+type resourceDescription struct {
+	oc               *exutil.CLI
+	asAdmin          bool
+	withoutNamespace bool
+	kind             string
+	name             string
+	requireNS        bool
+	namespace        string
+}
+
+//the method is to construc one resource so that it can be deleted with itResource and describerResrouce
+//oc is the oc client
+//asAdmin means when deleting resource, we take admin role
+//withoutNamespace means when deleting resource, we take WithoutNamespace
+//kind is the kind of resource
+//name is the name of resource
+//namespace is the namesapce of resoruce. it is "" for cluster level resource
+//if requireNS is requireNS, need to add "-n" parameter. used for project level resource
+//if requireNS is notRequireNS, no need to add "-n". used for cluster level resource
+func newResource(oc *exutil.CLI, kind string, name string, nsflag bool, namespace string) resourceDescription {
+	return resourceDescription{
+		oc:               oc,
+		asAdmin:          asAdmin,
+		withoutNamespace: withoutNamespace,
+		kind:             kind,
+		name:             name,
+		requireNS:        nsflag,
+		namespace:        namespace,
+	}
+}
+
+//the method is to delete resource.
+func (r resourceDescription) delete() {
+	if r.withoutNamespace && r.requireNS {
+		removeResource(r.oc, r.asAdmin, r.withoutNamespace, r.kind, r.name, "-n", r.namespace)
+	} else {
+		removeResource(r.oc, r.asAdmin, r.withoutNamespace, r.kind, r.name)
+	}
+}
+
+//the struct to save the resource created in g.It, and it take name+kind+namespace as key to save resoruce of g.It.
+type itResource map[string]resourceDescription
+
+func (ir itResource) add(r resourceDescription) {
+	ir[r.name+r.kind+r.namespace] = r
+}
+func (ir itResource) get(name string, kind string, namespace string) resourceDescription {
+	r, ok := ir[name+kind+namespace]
+	o.Expect(ok).To(o.BeTrue())
+	return r
+}
+func (ir itResource) remove(name string, kind string, namespace string) {
+	rKey := name + kind + namespace
+	if r, ok := ir[rKey]; ok {
+		r.delete()
+		delete(ir, rKey)
+	}
+}
+func (ir itResource) cleanup() {
+	for _, r := range ir {
+		e2e.Logf("cleanup resource %s,   %s", r.kind, r.name)
+		ir.remove(r.name, r.kind, r.namespace)
+	}
+}
+
+//the struct is to save g.It in g.Describe, and map the g.It name to itResource so that it can get all resource of g.Describe per g.It.
+type describerResrouce map[string]itResource
+
+func (dr describerResrouce) addIr(itName string) {
+	dr[itName] = itResource{}
+}
+func (dr describerResrouce) getIr(itName string) itResource {
+	ir, ok := dr[itName]
+	o.Expect(ok).To(o.BeTrue())
+	return ir
+}
+func (dr describerResrouce) rmIr(itName string) {
+	delete(dr, itName)
+}
+
+//the method is to convert to json format from one map sting got with -jsonpath
+func convertLMtoJSON(content string) string {
+	var jb strings.Builder
+	jb.WriteString("[")
+	items := strings.Split(strings.TrimSuffix(strings.TrimPrefix(content, "["), "]"), "map")
+	for _, item := range items {
+		if strings.Compare(item, "") == 0 {
+			continue
+		}
+		kvs := strings.Fields(strings.TrimSuffix(strings.TrimPrefix(item, "["), "]"))
+		jb.WriteString("{")
+		for ki, kv := range kvs {
+			p := strings.Split(kv, ":")
+			jb.WriteString("\"" + p[0] + "\":")
+			jb.WriteString("\"" + p[1] + "\"")
+			if ki < len(kvs)-1 {
+				jb.WriteString(", ")
+			}
+		}
+		jb.WriteString("},")
+	}
+	return strings.TrimSuffix(jb.String(), ",") + "]"
+}
+
+//the method is to get random string with length 8.
+func getRandomString() string {
+	chars := "abcdefghijklmnopqrstuvwxyz0123456789"
+	seed := rand.New(rand.NewSource(time.Now().UnixNano()))
+	buffer := make([]byte, 8)
+	for index := range buffer {
+		buffer[index] = chars[seed.Intn(len(chars))]
+	}
+	return string(buffer)
+}
+
+//the method is to update z version of kube version of platform.
+func generateUpdatedKubernatesVersion(oc *exutil.CLI) string {
+	subKubeVersions := strings.Split(getKubernetesVersion(oc), ".")
+	zVersion, _ := strconv.Atoi(subKubeVersions[1])
+	subKubeVersions[1] = strconv.Itoa(zVersion + 1)
+	return strings.Join(subKubeVersions[0:2], ".") + ".0"
+}
+
+//the method is to get kube versoin of the platform.
+func getKubernetesVersion(oc *exutil.CLI) string {
+	output, err := doAction(oc, "version", asAdmin, withoutNamespace, "-o=json")
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	var result map[string]interface{}
+	err = json.Unmarshal([]byte(output), &result)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	gitVersion := result["serverVersion"].(map[string]interface{})["gitVersion"]
+	e2e.Logf("gitVersion is %v", gitVersion)
+	return strings.TrimPrefix(gitVersion.(string), "v")
+}
+
+//the method is to create one resource with template
+func applyResourceFromTemplate(oc *exutil.CLI, parameters ...string) error {
+	var configFile string
+	err := wait.Poll(3*time.Second, 15*time.Second, func() (bool, error) {
+		output, err := oc.AsAdmin().Run("process").Args(parameters...).OutputToFile(getRandomString() + "olm-config.json")
+		if err != nil {
+			e2e.Logf("the err:%v, and try next round", err)
+			return false, nil
+		}
+		configFile = output
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	e2e.Logf("the file of resource is %s", configFile)
+	return oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", configFile).Execute()
+}
+
+//the method is to check the presence of the resource
+//asAdmin means if taking admin to check it
+//withoutNamespace means if take WithoutNamespace() to check it.
+//present means if you expect the resource presence or not. if it is ok, expect presence. if it is nok, expect not present.
+func isPresentResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, present bool, parameters ...string) bool {
+	parameters = append(parameters, "--ignore-not-found")
+	err := wait.Poll(3*time.Second, 60*time.Second, func() (bool, error) {
+		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
+		if err != nil {
+			e2e.Logf("the get error is %v, and try next", err)
+			return false, nil
+		}
+		if !present && strings.Compare(output, "") == 0 {
+			return true, nil
+		}
+		if present && strings.Compare(output, "") != 0 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+//the method is to patch one resource
+//asAdmin means if taking admin to patch it
+//withoutNamespace means if take WithoutNamespace() to patch it.
+func patchResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) {
+	_, err := doAction(oc, "patch", asAdmin, withoutNamespace, parameters...)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to execute something in pod to get output
+//asAdmin means if taking admin to execute it
+//withoutNamespace means if take WithoutNamespace() to execute it.
+func execResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) string {
+	var result string
+	err := wait.Poll(3*time.Second, 6*time.Second, func() (bool, error) {
+		output, err := doAction(oc, "exec", asAdmin, withoutNamespace, parameters...)
+		if err != nil {
+			e2e.Logf("the exec error is %v, and try next", err)
+			return false, nil
+		}
+		result = output
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("the result of exec resource:%v", result)
+	return result
+}
+
+//the method is to get something from resource. it is "oc get xxx" actaully
+//asAdmin means if taking admin to get it
+//withoutNamespace means if take WithoutNamespace() to get it.
+func getResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) string {
+	var result string
+	err := wait.Poll(3*time.Second, 120*time.Second, func() (bool, error) {
+		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
+		if err != nil {
+			e2e.Logf("the get error is %v, and try next", err)
+			return false, nil
+		}
+		result = output
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("the result of queried resource:%v", result)
+	return result
+}
+
+//the method is to check one resource's attribution is expected or not.
+//asAdmin means if taking admin to check it
+//withoutNamespace means if take WithoutNamespace() to check it.
+//isCompare means if containing or exactly comparing. if it is contain, it check result contain content. if it is compare, it compare the result with content exactly.
+//content is the substing to be expected
+//the expect is ok, contain or compare result is OK for method == expect, no error raise. if not OK, error raise
+//the expect is nok, contain or compare result is NOK for method == expect, no error raise. if OK, error raise
+func expectedResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, isCompare bool, content string, expect bool, parameters ...string) error {
+	cc := func(a, b string, ic bool) bool {
+		bs := strings.Split(b, "+2+")
+		ret := false
+		for _, s := range bs {
+			if (ic && strings.Compare(a, s) == 0) || (!ic && strings.Contains(a, s)) {
+				ret = true
+			}
+		}
+		return ret
+	}
+	return wait.Poll(3*time.Second, 150*time.Second, func() (bool, error) {
+		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
+		if err != nil {
+			e2e.Logf("the get error is %v, and try next", err)
+			return false, nil
+		}
+		e2e.Logf("the queried resource:%s", output)
+		if isCompare && expect && cc(output, content, isCompare) {
+			e2e.Logf("the output %s matches one of the content %s, expected", output, content)
+			return true, nil
+		}
+		if isCompare && !expect && !cc(output, content, isCompare) {
+			e2e.Logf("the output %s does not matche the content %s, expected", output, content)
+			return true, nil
+		}
+		if !isCompare && expect && cc(output, content, isCompare) {
+			e2e.Logf("the output %s contains one of the content %s, expected", output, content)
+			return true, nil
+		}
+		if !isCompare && !expect && !cc(output, content, isCompare) {
+			e2e.Logf("the output %s does not contain the content %s, expected", output, content)
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+//the method is to remove resource
+//asAdmin means if taking admin to remove it
+//withoutNamespace means if take WithoutNamespace() to remove it.
+func removeResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters ...string) {
+	output, err := doAction(oc, "delete", asAdmin, withoutNamespace, parameters...)
+	if err != nil && (strings.Contains(output, "NotFound") || strings.Contains(output, "No resources found")) {
+		e2e.Logf("the resource is deleted already")
+		return
+	}
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = wait.Poll(3*time.Second, 120*time.Second, func() (bool, error) {
+		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
+		if err != nil && (strings.Contains(output, "NotFound") || strings.Contains(output, "No resources found")) {
+			e2e.Logf("the resource is delete successfully")
+			return true, nil
+		}
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+//the method is to do something with oc.
+//asAdmin means if taking admin to do it
+//withoutNamespace means if take WithoutNamespace() to do it.
+func doAction(oc *exutil.CLI, action string, asAdmin bool, withoutNamespace bool, parameters ...string) (string, error) {
+	if asAdmin && withoutNamespace {
+		return oc.AsAdmin().WithoutNamespace().Run(action).Args(parameters...).Output()
+	}
+	if asAdmin && !withoutNamespace {
+		return oc.AsAdmin().Run(action).Args(parameters...).Output()
+	}
+	if !asAdmin && withoutNamespace {
+		return oc.WithoutNamespace().Run(action).Args(parameters...).Output()
+	}
+	if !asAdmin && !withoutNamespace {
+		return oc.Run(action).Args(parameters...).Output()
+	}
+	return "", nil
+}

--- a/test/extended/testdata/olm/etcd-cluster.yaml
+++ b/test/extended/testdata/olm/etcd-cluster.yaml
@@ -6,9 +6,12 @@ objects:
 - apiVersion: etcd.database.coreos.com/v1beta2
   kind: EtcdCluster
   metadata:
+    annotations:
+      etcd.database.coreos.com/scope: clusterwide
     name: "${NAME}"
     namespace: "${NAMESPACE}"
   spec:
+    repository: quay.io/coreos/etcd
     size: 3
     version: 3.2.13
 parameters:


### PR DESCRIPTION
As title, logs:
```console
[root@preserve-olm-env openshift-tests]#  ./bin/extended-platform-tests run all --dry-run|grep 23440|./bin/extended-platform-tests run -f -


I1223 12:31:10.890693    4468 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I1223 12:31:10.906853    4470 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"

I1223 12:31:12.889871    4575 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Dec 23 12:31:12.927: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Dec 23 12:31:12.945: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Dec 23 12:31:12.974: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Dec 23 12:31:12.975: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Dec 23 12:31:12.975: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Dec 23 12:31:12.984: INFO: e2e test version: v0.0.0-master+$Format:%h$
Dec 23 12:31:12.986: INFO: kube-apiserver version: v1.19.0+9c69bdc
Dec 23 12:31:12.994: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /data/goproject/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [sig-operators] OLM for an end user use
  /data/goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [sig-operators] OLM for an end user use
  /data/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:111
Dec 23 12:31:13.129: INFO: configPath is now "/tmp/configfile172230267"
Dec 23 12:31:13.129: INFO: The user is now "e2e-test-olm-7dxm9-user"
Dec 23 12:31:13.129: INFO: Creating project "e2e-test-olm-7dxm9"
Dec 23 12:31:13.363: INFO: Waiting on permissions in project "e2e-test-olm-7dxm9" ...
Dec 23 12:31:13.369: INFO: Waiting for ServiceAccount "default" to be provisioned...
Dec 23 12:31:13.477: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Dec 23 12:31:13.584: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Dec 23 12:31:13.693: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Dec 23 12:31:13.701: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Dec 23 12:31:13.708: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Dec 23 12:31:13.715: INFO: Project "e2e-test-olm-7dxm9" has been fully provisioned.
[It] Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]
  /data/goproject/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:148
Dec 23 12:31:13.788: INFO: configPath is now "/tmp/configfile330543518"
Dec 23 12:31:13.788: INFO: The user is now "e2e-test-olm-xm5dz-user"
Dec 23 12:31:13.788: INFO: Creating project "e2e-test-olm-xm5dz"
Dec 23 12:31:14.006: INFO: Waiting on permissions in project "e2e-test-olm-xm5dz" ...
Dec 23 12:31:14.010: INFO: Waiting for ServiceAccount "default" to be provisioned...
Dec 23 12:31:14.128: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Dec 23 12:31:14.235: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Dec 23 12:31:14.343: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Dec 23 12:31:14.350: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Dec 23 12:31:14.356: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Dec 23 12:31:14.365: INFO: Project "e2e-test-olm-xm5dz" has been fully provisioned.
STEP: Cluster-admin start to subscribe to etcd operator
Dec 23 12:31:17.509: INFO: the file of resource is /tmp/e2e-test-olm-xm5dz-pu8isl61olm-config.json
subscription.operators.coreos.com/sub-23440 created
Dec 23 12:31:21.132: INFO: the queried resource:UpgradePending
Dec 23 12:31:24.137: INFO: the queried resource:AtLatestKnown
Dec 23 12:31:24.137: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
Dec 23 12:31:27.295: INFO: the result of queried resource:etcdoperator.v0.9.4-clusterwide
Dec 23 12:31:27.295: INFO: the installed CSV name is etcdoperator.v0.9.4-clusterwide
Dec 23 12:31:30.437: INFO: the queried resource:Succeeded
Dec 23 12:31:30.437: INFO: the output Succeeded matches one of the content Succeeded, expected
STEP: Switch to common user to create the resources provided by the operator
etcdcluster.etcd.database.coreos.com/example-etcd-cluster created
Dec 23 12:31:33.907: INFO: the queried resource:
Dec 23 12:31:36.909: INFO: the queried resource:
Dec 23 12:31:39.909: INFO: the queried resource:
Dec 23 12:31:42.925: INFO: the queried resource:Running
Dec 23 12:31:42.925: INFO: the output Running matches one of the content Running, expected
Dec 23 12:31:46.397: INFO: Error running /usr/local/bin/oc --kubeconfig=/data/r-kubeconfig get csv etcdoperator.v0.9.4-clusterwide -n openshift-operators:
Error from server (NotFound): clusterserviceversions.operators.coreos.com "etcdoperator.v0.9.4-clusterwide" not found
Dec 23 12:31:46.397: INFO: the resource is delete successfully
Dec 23 12:31:49.686: INFO: Error running /usr/local/bin/oc --kubeconfig=/data/r-kubeconfig get sub sub-23440 -n openshift-operators:
Error from server (NotFound): subscriptions.operators.coreos.com "sub-23440" not found
Dec 23 12:31:49.686: INFO: the resource is delete successfully
[AfterEach] [sig-operators] OLM for an end user use
  /data/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:102
Dec 23 12:31:49.714: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-7dxm9-user}, err: <nil>
Dec 23 12:31:49.729: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-7dxm9}, err: <nil>
Dec 23 12:31:49.742: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  AxPybtBgQuSXTdVOzJHLogAAAAAAAAAA}, err: <nil>
Dec 23 12:31:49.779: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-xm5dz-user}, err: <nil>
Dec 23 12:31:49.797: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-xm5dz}, err: <nil>
Dec 23 12:31:49.810: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  IlGfywrnTsCdptCjP4vb0AAAAAAAAAAA}, err: <nil>
Dec 23 12:31:49.816: INFO: Running AfterSuite actions on all nodes
Dec 23 12:31:49.816: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
Dec 23 12:31:49.826: INFO: Found DeleteNamespace=false, skipping namespace deletion!
Dec 23 12:31:49.826: INFO: Running AfterSuite actions on node 1

passed: (38.9s) 2020-12-23T12:31:49 "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"


Timeline:

Dec 23 12:31:20.885 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide requirements not yet checked
Dec 23 12:31:20.979 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide one or more requirements couldn't be found
Dec 23 12:31:21.285 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide all requirements found, attempting install
Dec 23 12:31:21.355 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide waiting for install components to report healthy
Dec 23 12:31:21.392 I ns/openshift-operators deployment/etcd-operator Scaled up replica set etcd-operator-787cb969d7 to 1
Dec 23 12:31:21.439 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg node/ created
Dec 23 12:31:21.456 I ns/openshift-operators replicaset/etcd-operator-787cb969d7 Created pod: etcd-operator-787cb969d7-hgbmg
Dec 23 12:31:21.457 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for deployment spec update to be observed...\n
Dec 23 12:31:21.484 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Successfully assigned openshift-operators/etcd-operator-787cb969d7-hgbmg to knarra46z-lbmr5-compute-2
Dec 23 12:31:21.691 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n
Dec 23 12:31:23.603 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Add eth0 [10.128.2.144/23]
Dec 23 12:31:23.907 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Dec 23 12:31:24.063 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Created container etcd-operator
Dec 23 12:31:24.096 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Started container etcd-operator
Dec 23 12:31:24.103 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Dec 23 12:31:24.254 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Created container etcd-backup-operator
Dec 23 12:31:24.289 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Started container etcd-backup-operator
Dec 23 12:31:24.297 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Dec 23 12:31:24.448 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Created container etcd-restore-operator
Dec 23 12:31:24.488 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Started container etcd-restore-operator
Dec 23 12:31:25.341 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide install strategy completed with no errors
Dec 23 12:31:41.528 I ns/openshift-operators endpoints/etcd-operator etcd-operator-787cb969d7-hgbmg became leader
Dec 23 12:31:41.704 I ns/openshift-operators endpoints/etcd-backup-operator etcd-operator-787cb969d7-hgbmg became leader
Dec 23 12:31:41.972 I ns/openshift-operators endpoints/etcd-restore-operator etcd-operator-787cb969d7-hgbmg became leader
Dec 23 12:31:43.326 W ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg node/knarra46z-lbmr5-compute-2 graceful deletion within 30s
Dec 23 12:31:43.339 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Stopping container etcd-operator
Dec 23 12:31:43.352 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Stopping container etcd-restore-operator
Dec 23 12:31:43.391 I ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg Stopping container etcd-backup-operator
Dec 23 12:31:44.206 E ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg node/knarra46z-lbmr5-compute-2 container=etcd-backup-operator container exited with code 2 (Error): 
Dec 23 12:31:44.206 E ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg node/knarra46z-lbmr5-compute-2 container=etcd-operator container exited with code 2 (Error): 
Dec 23 12:31:44.206 E ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg node/knarra46z-lbmr5-compute-2 container=etcd-restore-operator container exited with code 2 (Error): 
Dec 23 12:31:48.776 W ns/openshift-operators pod/etcd-operator-787cb969d7-hgbmg node/knarra46z-lbmr5-compute-2 deleted

1 pass, 0 skip (38.9s)

```