### PR TITLE
enable parallelism so that we can set number when starting testing

### DIFF
--- a/cmd/extended-platform-tests/openshift-tests.go
+++ b/cmd/extended-platform-tests/openshift-tests.go
@@ -273,6 +273,7 @@ func bindOptions(opt *testginkgo.Options, flags *pflag.FlagSet) {
 	flags.IntVar(&opt.Count, "count", opt.Count, "Run each test a specified number of times. Defaults to 1 or the suite's preferred value.")
 	flags.DurationVar(&opt.Timeout, "timeout", opt.Timeout, "Set the maximum time a test can run before being aborted. This is read from the suite by default, but will be 10 minutes otherwise.")
 	flags.BoolVar(&opt.IncludeSuccessOutput, "include-success", opt.IncludeSuccessOutput, "Print output from successful tests.")
+	flags.IntVar(&opt.Parallelism, "max-parallel-tests", opt.Parallelism, "Maximum number of tests running in parallel. 0 defaults to test suite recommended value, which is different in each suite.")
 }
 
 func initProvider(provider string, dryRun bool) error {


### PR DESCRIPTION
@jianzhangbjz @bandrade could you please review it? thanks
```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run|grep OLM|./bin/extended-platform-tests run --parallelism 5 -f -
I1224 17:34:37.089017   86072 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I1224 17:34:39.767530   86074 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/16) "[sig-operators] OLM for an end user handle within a namespace ConnectedOnly-High-25855-Add the channel field to subscription_sync_count [Suite:openshift/conformance/parallel]"

started: (0/2/16) "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"

started: (0/3/16) "[sig-operators] OLM should High-36803-OLM is installed with clusterserviceversions at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/4/16) "[sig-operators] OLM should High-27589-do not use ipv4 addresses in CatalogSources generated by marketplace [Suite:openshift/conformance/parallel]"

started: (0/5/16) "[sig-operators] OLM should High-36803-OLM is installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"

^CInterrupted, terminating tests

kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run|grep OLM|./bin/extended-platform-tests run  -f -               
I1224 17:34:53.249996   86083 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I1224 17:34:55.216253   86085 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/16) "[sig-operators] OLM should High-36803-OLM is installed with catalogsources at version v1alpha1 [Suite:openshift/conformance/parallel]"

started: (0/2/16) "[sig-operators] OLM should High-24061-have imagePullPolicy:IfNotPresent on thier deployments [Suite:openshift/conformance/parallel]"

started: (0/3/16) "[sig-operators] OLM should High-36803-OLM is installed with operatorgroups at version v1 [Suite:openshift/conformance/parallel]"

^CInterrupted, terminating tests
```