### PR TITLE
don´t assume service subnet is always the same

### DIFF
--- a/test/extended/testdata/cmd/test/cmd/observe.sh
+++ b/test/extended/testdata/cmd/test/cmd/observe.sh
@@ -28,8 +28,9 @@ os::cmd::expect_failure_and_text 'oc observe services --exit-after=1m --all-name
 os::cmd::expect_failure_and_text 'oc observe services --exit-after=1m --all-namespaces --retry-on-exit-code=2 --maximum-errors=1 --loglevel=4 -- /bin/sh -c "exit 2"' 'retrying command: exit status 2'
 
 # argument templates
-os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{ .spec.clusterIP }"' '172.30.0.1'
-os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{{ .spec.clusterIP }}" --output=gotemplate' '172.30.0.1'
+# The ClusterIP of the kubernetes.default service will always end in .1
+os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{ .spec.clusterIP }"' '.1'
+os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{{ .spec.clusterIP }}" --output=gotemplate' '.1'
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "bad{ .missingkey }key"' 'badkey'
 os::cmd::expect_failure_and_text 'oc observe services --once --all-namespaces -a "bad{ .missingkey }key" --strict-templates' 'missingkey is not found'
 os::cmd::expect_success_and_text 'oc observe services --once --all-namespaces -a "{{ .unknown }}" --output=gotemplate' '""'

--- a/test/extended/testdata/cmd/test/cmd/testdata/external-service.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/external-service.yaml
@@ -7,7 +7,6 @@ metadata:
   resourceVersion: "1"
   uid: 19cff995-5546-11e5-9f57-080027c5bfa9
 spec:
-  clusterIP: 172.30.0.100
   ports:
   - nodePort: 0
     port: 443

--- a/test/extended/testdata/cmd/test/cmd/testdata/multiport-service.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/multiport-service.yaml
@@ -11,7 +11,6 @@ items:
     resourceVersion: "259"
     uid: 024d82eb-7193-11e5-b84d-080027c5bfa9
   spec:
-    clusterIP: 172.30.182.32
     ports:
     - name: web
       port: 5432


### PR DESCRIPTION
The apiservers allocates a free ClusterIP for a Service if this field is not set.
To make the tests more portable, we can´t assume that we know the service-subnet.
Another option is to add the service subnet as a parameter and modify the IPs based on that