### PR TITLE
update bindata.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build
+all: update build
 .PHONY: all
 
 OUT_DIR=bin


### PR DESCRIPTION
update bindata.go

zhaoxia@wangshanshandeMacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run | grep "23440" | ./bin/extended-platform-tests run --junit-dir=./ -f -
I0222 17:33:16.146202   11003 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0222 17:33:19.086378   11005 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"

I0222 17:33:27.949778   11011 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Feb 22 17:33:27.981: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Feb 22 17:33:28.824: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Feb 22 17:33:29.741: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Feb 22 17:33:29.741: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Feb 22 17:33:29.741: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Feb 22 17:33:30.135: INFO: e2e test version: v0.0.0-master+$Format:%h$
Feb 22 17:33:30.343: INFO: kube-apiserver version: v1.20.0+01ab7fd
Feb 22 17:33:30.561: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /Users/zhaoxia/go/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/zhaoxia/go/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/zhaoxia/go/src/github.com/openshift/openshift-tests/test/extended/util/client.go:111
Feb 22 17:33:32.364: INFO: configPath is now "/var/folders/lz/0cpy7z2d0_194s6j0smb4znw0000gp/T/configfile969900549"
Feb 22 17:33:32.364: INFO: The user is now "e2e-test-olm-vjb88-user"
Feb 22 17:33:32.364: INFO: Creating project "e2e-test-olm-vjb88"
Feb 22 17:33:32.718: INFO: Waiting on permissions in project "e2e-test-olm-vjb88" ...
Feb 22 17:33:32.952: INFO: Waiting for ServiceAccount "default" to be provisioned...
Feb 22 17:33:33.274: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Feb 22 17:33:33.596: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Feb 22 17:33:33.914: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Feb 22 17:33:34.347: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Feb 22 17:33:34.777: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Feb 22 17:33:35.204: INFO: Project "e2e-test-olm-vjb88" has been fully provisioned.
[It] Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]
  /Users/zhaoxia/go/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:149
Feb 22 17:33:36.611: INFO: configPath is now "/var/folders/lz/0cpy7z2d0_194s6j0smb4znw0000gp/T/configfile187737504"
Feb 22 17:33:36.611: INFO: The user is now "e2e-test-olm-w52z6-user"
Feb 22 17:33:36.611: INFO: Creating project "e2e-test-olm-w52z6"
Feb 22 17:33:36.905: INFO: Waiting on permissions in project "e2e-test-olm-w52z6" ...
Feb 22 17:33:37.123: INFO: Waiting for ServiceAccount "default" to be provisioned...
Feb 22 17:33:37.446: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Feb 22 17:33:37.766: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Feb 22 17:33:38.083: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Feb 22 17:33:38.521: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Feb 22 17:33:38.954: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Feb 22 17:33:39.391: INFO: Project "e2e-test-olm-w52z6" has been fully provisioned.
STEP: Cluster-admin start to subscribe to etcd operator
Feb 22 17:33:43.273: INFO: the file of resource is /tmp/e2e-test-olm-w52z6-dls7mc8volm-config.json
subscription.operators.coreos.com/sub-23440 created
Feb 22 17:33:52.356: INFO: the queried resource:UpgradePending
Feb 22 17:33:55.343: INFO: the queried resource:UpgradePending
Feb 22 17:33:58.340: INFO: the queried resource:UpgradePending
Feb 22 17:34:01.359: INFO: the queried resource:AtLatestKnown
Feb 22 17:34:01.359: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
Feb 22 17:34:05.206: INFO: the result of queried resource:etcdoperator.v0.9.4-clusterwide
Feb 22 17:34:05.206: INFO: the installed CSV name is etcdoperator.v0.9.4-clusterwide
Feb 22 17:34:09.263: INFO: the queried resource:
Feb 22 17:34:17.363: INFO: the queried resource:Succeeded
Feb 22 17:34:17.363: INFO: the output Succeeded matches one of the content Succeeded, expected
STEP: Switch to common user to create the resources provided by the operator
etcdcluster.etcd.database.coreos.com/example-etcd-cluster created
Feb 22 17:34:22.912: INFO: the queried resource:Running
Feb 22 17:34:22.912: INFO: the output Running matches one of the content Running, expected
Feb 22 17:34:29.175: INFO: Error running /usr/local/go/bin/oc --kubeconfig=/Users/zhaoxia/kube-config get csv etcdoperator.v0.9.4-clusterwide -n openshift-operators:
Error from server (NotFound): clusterserviceversions.operators.coreos.com "etcdoperator.v0.9.4-clusterwide" not found
Feb 22 17:34:29.175: INFO: the resource is delete successfully
Feb 22 17:34:34.217: INFO: Error running /usr/local/go/bin/oc --kubeconfig=/Users/zhaoxia/kube-config get sub sub-23440 -n openshift-operators:
Error from server (NotFound): subscriptions.operators.coreos.com "sub-23440" not found
Feb 22 17:34:34.217: INFO: the resource is delete successfully
[AfterEach] [sig-operators] OLM for an end user use
  /Users/zhaoxia/go/src/github.com/openshift/openshift-tests/test/extended/util/client.go:102
Feb 22 17:34:34.446: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-vjb88-user}, err: <nil>
Feb 22 17:34:34.672: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-vjb88}, err: <nil>
Feb 22 17:34:34.895: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  mxZWZeBMR9aXqyt_2po4_gAAAAAAAAAA}, err: <nil>
Feb 22 17:34:35.115: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-w52z6-user}, err: <nil>
Feb 22 17:34:35.333: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-w52z6}, err: <nil>
Feb 22 17:34:35.551: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  m_CTdrQCQsifjwsE4UgxXQAAAAAAAAAA}, err: <nil>
[AfterEach] [sig-operators] OLM for an end user use
  /Users/zhaoxia/go/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Feb 22 17:34:35.551: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-vjb88" for this suite.
STEP: Destroying namespace "e2e-test-olm-w52z6" for this suite.
Feb 22 17:34:36.665: INFO: Running AfterSuite actions on all nodes
Feb 22 17:34:36.665: INFO: Running AfterSuite actions on node 1

passed: (1m18s) 2021-02-22T09:34:36 "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator [Suite:openshift/conformance/parallel]"


Timeline:

Feb 22 09:33:22.917 I ns/openshift-marketplace pod/efcdc6057d84f021de8dd9155e302cd0dd04a99920133dd6f90d9e8112mjdl9 node/ip-10-0-188-204.us-east-2.compute.internal created
Feb 22 09:33:48.888 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj node/ created
Feb 22 09:33:48.895 I ns/openshift-marketplace job/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfbff3b Created pod: eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj
Feb 22 09:33:48.901 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Successfully assigned openshift-marketplace/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj to ip-10-0-188-204.us-east-2.compute.internal
Feb 22 09:33:51.299 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Add eth0 [10.131.0.147/23]
Feb 22 09:33:51.639 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Container image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:c297376501d9f98327741fab50d82bf39c1f2b7153997ee680b04b23d44fcf33" already present on machine
Feb 22 09:33:51.760 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Created container util
Feb 22 09:33:51.788 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Started container util
Feb 22 09:33:52.762 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Pulling image "quay.io/openshift-community-operators/etcd:v0.9.4-clusterwide"
Feb 22 09:33:54.619 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Successfully pulled image "quay.io/openshift-community-operators/etcd:v0.9.4-clusterwide" in 1.852106424s
Feb 22 09:33:54.751 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Created container pull
Feb 22 09:33:54.793 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Started container pull
Feb 22 09:33:55.773 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Container image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:42e7c7c1cae80d9868c9a8ede58fe8303a857f7dbf7642772bc5d9a75f0a9cd0" already present on machine
Feb 22 09:33:55.902 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Created container extract
Feb 22 09:33:56.002 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bf295xj Started container extract
Feb 22 09:33:56.874 I ns/openshift-marketplace job/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfbff3b Job completed
Feb 22 09:33:59.407 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide requirements not yet checked
Feb 22 09:33:59.534 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide all requirements found, attempting install
Feb 22 09:33:59.606 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide waiting for install components to report healthy
Feb 22 09:33:59.621 I ns/openshift-operators deployment/etcd-operator Scaled up replica set etcd-operator-7575d9f47 to 1
Feb 22 09:33:59.666 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 node/ created
Feb 22 09:33:59.765 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for deployment spec update to be observed...\n
Feb 22 09:33:59.903 I ns/openshift-operators replicaset/etcd-operator-7575d9f47 Created pod: etcd-operator-7575d9f47-nmsg9
Feb 22 09:33:59.903 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Successfully assigned openshift-operators/etcd-operator-7575d9f47-nmsg9 to ip-10-0-188-204.us-east-2.compute.internal
Feb 22 09:34:00.133 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n
Feb 22 09:34:00.133 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n (2 times)
Feb 22 09:34:01.215 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Add eth0 [10.131.0.148/23]
Feb 22 09:34:01.580 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Feb 22 09:34:01.710 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Created container etcd-operator
Feb 22 09:34:01.734 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Started container etcd-operator
Feb 22 09:34:01.739 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Feb 22 09:34:01.867 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Created container etcd-backup-operator
Feb 22 09:34:01.940 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Started container etcd-backup-operator
Feb 22 09:34:01.965 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Feb 22 09:34:02.038 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Created container etcd-restore-operator
Feb 22 09:34:02.075 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Started container etcd-restore-operator
Feb 22 09:34:02.996 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide install strategy completed with no errors
Feb 22 09:34:24.969 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Stopping container etcd-restore-operator
Feb 22 09:34:24.970 W ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 node/ip-10-0-188-204.us-east-2.compute.internal graceful deletion within 30s
Feb 22 09:34:24.976 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Stopping container etcd-backup-operator
Feb 22 09:34:25.193 I ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 Stopping container etcd-operator
Feb 22 09:34:25.882 E ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 node/ip-10-0-188-204.us-east-2.compute.internal container=etcd-backup-operator container exited with code 2 (Error): 
Feb 22 09:34:25.882 E ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 node/ip-10-0-188-204.us-east-2.compute.internal container=etcd-operator container exited with code 2 (Error): 
Feb 22 09:34:25.882 E ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 node/ip-10-0-188-204.us-east-2.compute.internal container=etcd-restore-operator container exited with code 2 (Error): 
Feb 22 09:34:27.742 W ns/openshift-operators pod/etcd-operator-7575d9f47-nmsg9 node/ip-10-0-188-204.us-east-2.compute.internal deleted

Writing JUnit report to junit_e2e_20210222-093436.xml

1 pass, 0 skip (1m18s)
