### PR TITLE
fix namespaces ci-op-tlqcpfhs not found

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -168,10 +168,10 @@ var _ = g.Describe("[sig-operators] OLM for an end user use", func() {
 			singleNamespace:        false,
 			template:               subTemplate,
 		}
-		sub.create(oc, itName, dr)
 		defer sub.delete(itName, dr)
+		sub.create(oc, itName, dr)
 		defer sub.getCSV().delete(itName, dr)
-		newCheck("expect", asAdmin, true, compare, "Succeeded", ok, []string{"csv", sub.installedCSV, "-o=jsonpath={.status.phase}"}).check(oc)
+		newCheck("expect", asAdmin, true, compare, "Succeeded", ok, []string{"csv", sub.installedCSV, "-n", "openshift-operators", "-o=jsonpath={.status.phase}"}).check(oc)
 
 		g.By("Switch to common user to create the resources provided by the operator")
 		etcdClusterName := "example-etcd-cluster"
@@ -185,8 +185,7 @@ var _ = g.Describe("[sig-operators] OLM for an end user use", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}()
 
-		newCheck("expect", false, true, compare, "Running", ok, []string{"etcdCluster", etcdClusterName, "-o=jsonpath={.status.phase}"}).check(oc)
-
+		newCheck("expect", false, true, compare, "Running", ok, []string{"etcdCluster", etcdClusterName, "-n", oc.Namespace(), "-o=jsonpath={.status.phase}"}).check(oc)
 	})
 })
 


### PR DESCRIPTION
Fix this issue:
```console
Mar  4 11:44:11.066: INFO: the installed CSV name is etcdoperator.v0.9.4-clusterwide
Mar  4 11:44:14.347: INFO: Error running /cli/oc --kubeconfig=/tmp/kubeconfig-209527395 get csv etcdoperator.v0.9.4-clusterwide -o=jsonpath={.status.phase}:
Error from server (NotFound): namespaces "ci-op-tlqcpfhs" not found
```
Logs:
```console
mac:openshift-tests jianzhang$ ./bin/extended-platform-tests run all --dry-run |grep 23440|./bin/extended-platform-tests run -f -
I0305 10:09:05.766355   50745 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0305 10:09:08.940034   50747 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]"

I0305 10:09:23.077854   50747 trace.go:116] Trace[1593735265]: "Reflector ListAndWatch" name:pkg/mod/github.com/openshift/kubernetes-client-go@v0.0.0-20200106170045-1fda2942f64d/tools/cache/reflector.go:105 (started: 2021-03-05 10:09:08.980502 +0800 CST m=+20.429396678) (total time: 14.096884358s):
Trace[1593735265]: [14.096833264s] [14.096833264s] Objects listed
I0305 10:09:28.471838   50747 trace.go:116] Trace[1608427340]: "Reflector ListAndWatch" name:pkg/mod/github.com/openshift/kubernetes-client-go@v0.0.0-20200106170045-1fda2942f64d/tools/cache/reflector.go:105 (started: 2021-03-05 10:09:08.978708 +0800 CST m=+20.427601886) (total time: 19.492546824s):
Trace[1608427340]: [19.492473748s] [19.492473748s] Objects listed
I0305 10:09:50.421738   50747 trace.go:116] Trace[564390048]: "Reflector ListAndWatch" name:pkg/mod/github.com/openshift/kubernetes-client-go@v0.0.0-20200106170045-1fda2942f64d/tools/cache/reflector.go:105 (started: 2021-03-05 10:09:08.978708 +0800 CST m=+20.427602008) (total time: 41.4418151s):
Trace[564390048]: [41.441558214s] [41.441558214s] Objects listed
I0305 10:09:26.747920   50753 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Mar  5 10:09:26.784: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Mar  5 10:09:35.056: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Mar  5 10:09:36.793: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (1 seconds elapsed)
Mar  5 10:09:36.793: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Mar  5 10:09:36.793: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Mar  5 10:09:37.334: INFO: e2e test version: v0.0.0-master+$Format:%h$
Mar  5 10:09:37.571: INFO: kube-apiserver version: v1.20.0+2ce2be0
Mar  5 10:09:37.889: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:111
Mar  5 10:09:40.168: INFO: configPath is now "/var/folders/2c/4whhm34n7892mf9l2j02cf480000gn/T/configfile760897291"
Mar  5 10:09:40.168: INFO: The user is now "e2e-test-olm-pd49g-user"
Mar  5 10:09:40.168: INFO: Creating project "e2e-test-olm-pd49g"
Mar  5 10:09:40.553: INFO: Waiting on permissions in project "e2e-test-olm-pd49g" ...
Mar  5 10:09:40.848: INFO: Waiting for ServiceAccount "default" to be provisioned...
Mar  5 10:09:41.189: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Mar  5 10:09:41.527: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Mar  5 10:09:41.867: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Mar  5 10:09:42.394: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Mar  5 10:09:43.419: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Mar  5 10:09:43.893: INFO: Project "e2e-test-olm-pd49g" has been fully provisioned.
[It] Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:149
Mar  5 10:09:49.052: INFO: configPath is now "/var/folders/2c/4whhm34n7892mf9l2j02cf480000gn/T/configfile469757678"
Mar  5 10:09:49.052: INFO: The user is now "e2e-test-olm-tk6wj-user"
Mar  5 10:09:49.052: INFO: Creating project "e2e-test-olm-tk6wj"
Mar  5 10:09:50.588: INFO: Waiting on permissions in project "e2e-test-olm-tk6wj" ...
Mar  5 10:09:51.179: INFO: Waiting for ServiceAccount "default" to be provisioned...
Mar  5 10:09:51.519: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Mar  5 10:09:51.860: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Mar  5 10:09:52.229: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Mar  5 10:09:52.844: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Mar  5 10:09:53.454: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Mar  5 10:09:53.920: INFO: Project "e2e-test-olm-tk6wj" has been fully provisioned.
STEP: Cluster-admin start to subscribe to etcd operator
Mar  5 10:09:58.375: INFO: the file of resource is /tmp/e2e-test-olm-tk6wj-rmfztgtfolm-config.json
E0305 10:10:30.607201   50766 request.go:1001] Unexpected error when reading response body: net/http: request canceled (Client.Timeout or context cancellation while reading body)
subscription.operators.coreos.com/sub-23440 created
Mar  5 10:10:39.225: INFO: the queried resource:UpgradePending
Mar  5 10:10:41.675: INFO: the queried resource:UpgradePending
Mar  5 10:10:44.830: INFO: the queried resource:UpgradePending
Mar  5 10:10:48.177: INFO: the queried resource:UpgradePending
Mar  5 10:10:53.059: INFO: the queried resource:UpgradePending
Mar  5 10:11:00.167: INFO: the queried resource:AtLatestKnown
Mar  5 10:11:00.167: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
Mar  5 10:11:04.374: INFO: the result of queried resource:etcdoperator.v0.9.4-clusterwide
Mar  5 10:11:04.374: INFO: the installed CSV name is etcdoperator.v0.9.4-clusterwide
Mar  5 10:11:11.509: INFO: the queried resource:Succeeded
Mar  5 10:11:11.509: INFO: the output Succeeded matches one of the content Succeeded, expected
STEP: Switch to common user to create the resources provided by the operator
etcdcluster.etcd.database.coreos.com/example-etcd-cluster created
Mar  5 10:11:26.494: INFO: the queried resource:Running
Mar  5 10:11:26.494: INFO: the output Running matches one of the content Running, expected
Mar  5 10:11:38.626: INFO: Error running /usr/local/bin/oc --kubeconfig=/Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/cho-kubeconfig get csv etcdoperator.v0.9.4-clusterwide -n openshift-operators:
Error from server (NotFound): clusterserviceversions.operators.coreos.com "etcdoperator.v0.9.4-clusterwide" not found
Mar  5 10:11:38.626: INFO: the resource is delete successfully
Mar  5 10:11:44.329: INFO: Error running /usr/local/bin/oc --kubeconfig=/Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/cho-kubeconfig get sub sub-23440 -n openshift-operators:
Error from server (NotFound): subscriptions.operators.coreos.com "sub-23440" not found
Mar  5 10:11:44.329: INFO: the resource is delete successfully
[AfterEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:102
Mar  5 10:11:45.356: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-pd49g-user}, err: <nil>
Mar  5 10:11:45.596: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-pd49g}, err: <nil>
Mar  5 10:11:46.684: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  q4RglrppTLiyTuCG7u6ijgAAAAAAAAAA}, err: <nil>
Mar  5 10:11:47.147: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-tk6wj-user}, err: <nil>
Mar  5 10:11:47.400: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-tk6wj}, err: <nil>
Mar  5 10:11:47.640: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  qad4zs1iRfyR7JoqloQjyAAAAAAAAAAA}, err: <nil>
[AfterEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Mar  5 10:11:47.640: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-pd49g" for this suite.
STEP: Destroying namespace "e2e-test-olm-tk6wj" for this suite.
Mar  5 10:11:55.621: INFO: Running AfterSuite actions on all nodes
Mar  5 10:11:55.621: INFO: Running AfterSuite actions on node 1

passed: (2m47s) 2021-03-05T02:11:55 "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]"


Timeline:

Mar 05 02:09:12.984 E kube-apiserver Kube API started failing: Get "https://api.chuo0305.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Mar 05 02:09:12.984 I openshift-apiserver OpenShift API started failing: Get "https://api.chuo0305.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Mar 05 02:09:23.984 - 15s   E kube-apiserver Kube API is not responding to GET requests
Mar 05 02:09:23.984 - 15s   E openshift-apiserver OpenShift API is not responding to GET requests
Mar 05 02:09:33.694 I ns/openshift-marketplace pod/redhat-marketplace-wpvsz Stopping container registry-server
Mar 05 02:09:33.694 I ns/openshift-marketplace pod/redhat-marketplace-wpvsz Stopping container registry-server (2 times)
Mar 05 02:09:33.694 W ns/openshift-marketplace pod/qe-app-registry-5nl88 Error: ImagePullBackOff (66 times)
Mar 05 02:09:37.334 I ns/openshift-marketplace pod/community-operators-2s9fj Successfully assigned openshift-marketplace/community-operators-2s9fj to ip-10-0-73-11.us-east-2.compute.internal
Mar 05 02:09:37.562 I ns/openshift-marketplace pod/community-operators-2s9fj Add eth0 [10.128.2.44/23]
Mar 05 02:09:37.562 I ns/openshift-marketplace pod/community-operators-2s9fj Pulling image "registry.redhat.io/redhat/community-operator-index:v4.7"
Mar 05 02:09:37.562 I ns/openshift-marketplace pod/community-operators-2s9fj Successfully pulled image "registry.redhat.io/redhat/community-operator-index:v4.7" in 1.556409591s
Mar 05 02:09:37.562 I ns/openshift-marketplace pod/community-operators-2s9fj Created container registry-server
Mar 05 02:09:37.562 I ns/openshift-marketplace pod/community-operators-2s9fj Started container registry-server
Mar 05 02:09:49.220 I ns/openshift-marketplace pod/community-operators-2s9fj Stopping container registry-server
Mar 05 02:09:49.220 I ns/openshift-marketplace pod/community-operators-2s9fj Stopping container registry-server (2 times)
Mar 05 02:09:49.220 I ns/openshift-marketplace pod/community-operators-kq9dx Successfully assigned openshift-marketplace/community-operators-kq9dx to ip-10-0-73-11.us-east-2.compute.internal
Mar 05 02:09:50.422 I ns/openshift-marketplace pod/redhat-marketplace-wpvsz node/ip-10-0-73-11.us-east-2.compute.internal created
Mar 05 02:09:50.609 I ns/openshift-marketplace pod/community-operators-kq9dx Add eth0 [10.128.2.45/23]
Mar 05 02:09:50.610 I ns/openshift-marketplace pod/community-operators-kq9dx Pulling image "registry.redhat.io/redhat/community-operator-index:v4.7"
Mar 05 02:09:50.610 I ns/openshift-marketplace pod/community-operators-kq9dx Successfully pulled image "registry.redhat.io/redhat/community-operator-index:v4.7" in 2.185219358s
Mar 05 02:09:50.895 I ns/openshift-marketplace pod/community-operators-kq9dx Created container registry-server
Mar 05 02:09:50.895 I ns/openshift-marketplace pod/community-operators-kq9dx Started container registry-server
Mar 05 02:09:51.183 I openshift-apiserver OpenShift API started responding to GET requests
Mar 05 02:09:51.183 I kube-apiserver Kube API started responding to GET requests
Mar 05 02:09:51.817 W ns/openshift-marketplace pod/redhat-marketplace-wpvsz node/ip-10-0-73-11.us-east-2.compute.internal graceful deletion within 0s
Mar 05 02:09:52.045 W ns/openshift-marketplace pod/redhat-marketplace-wpvsz node/ip-10-0-73-11.us-east-2.compute.internal deleted
Mar 05 02:09:52.844 I ns/openshift-marketplace pod/community-operators-2s9fj node/ created
Mar 05 02:09:53.985 - 120s  W ns/openshift-marketplace pod/qe-app-registry-5nl88 node/ip-10-0-73-11.us-east-2.compute.internal pod has been pending longer than a minute
Mar 05 02:09:53.985 - 120s  W ns/openshift-marketplace pod/qe-app-registry-5bslm node/ip-10-0-57-158.us-east-2.compute.internal pod has been pending longer than a minute
Mar 05 02:09:54.184 I openshift-apiserver OpenShift API started failing: Get "https://api.chuo0305.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 05 02:09:54.184 E kube-apiserver Kube API started failing: Get "https://api.chuo0305.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 05 02:09:56.935 W ns/openshift-marketplace pod/community-operators-2s9fj node/ip-10-0-73-11.us-east-2.compute.internal graceful deletion within 0s
Mar 05 02:09:57.391 W ns/openshift-marketplace pod/community-operators-2s9fj node/ip-10-0-73-11.us-east-2.compute.internal deleted
Mar 05 02:09:57.619 I ns/openshift-marketplace pod/community-operators-kq9dx node/ created
Mar 05 02:10:00.132 I kube-apiserver Kube API started responding to GET requests
Mar 05 02:10:00.132 I openshift-apiserver OpenShift API started responding to GET requests
Mar 05 02:10:02.148 W ns/openshift-marketplace pod/community-operators-kq9dx node/ip-10-0-73-11.us-east-2.compute.internal graceful deletion within 0s
Mar 05 02:10:02.830 I ns/openshift-marketplace pod/community-operators-kq9dx Stopping container registry-server
Mar 05 02:10:02.831 I ns/openshift-marketplace pod/community-operators-kq9dx Stopping container registry-server (2 times)
Mar 05 02:10:02.831 W ns/openshift-marketplace pod/community-operators-kq9dx node/ip-10-0-73-11.us-east-2.compute.internal deleted
Mar 05 02:10:37.350 I ns/openshift-marketplace job/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfbff3b Created pod: eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd
Mar 05 02:10:37.350 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd node/ created
Mar 05 02:10:37.910 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Successfully assigned openshift-marketplace/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd to ip-10-0-73-11.us-east-2.compute.internal
Mar 05 02:10:38.918 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Add eth0 [10.128.2.46/23]
Mar 05 02:10:39.618 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Pulling image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9f31d1d870010553210202b006348cd6e30f5a58ce841bab8b8cb89569c51735"
Mar 05 02:10:43.984 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Successfully pulled image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9f31d1d870010553210202b006348cd6e30f5a58ce841bab8b8cb89569c51735" in 4.813274429s
Mar 05 02:10:43.984 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Created container util
Mar 05 02:10:43.984 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Started container util
Mar 05 02:10:44.739 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Pulling image "quay.io/openshift-community-operators/etcd:v0.9.4-clusterwide"
Mar 05 02:10:47.509 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Successfully pulled image "quay.io/openshift-community-operators/etcd:v0.9.4-clusterwide" in 1.108857348s
Mar 05 02:10:47.568 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Created container pull
Mar 05 02:10:48.171 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Started container pull
Mar 05 02:10:48.171 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Pulling image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:88155ed8866c43f952fe4bea16b71280688d2e3a534a0cf5ab1206f084139dd5"
Mar 05 02:10:54.896 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Successfully pulled image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:88155ed8866c43f952fe4bea16b71280688d2e3a534a0cf5ab1206f084139dd5" in 7.598762559s
Mar 05 02:10:54.896 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Created container extract
Mar 05 02:10:54.896 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfmn2gd Started container extract
Mar 05 02:10:57.262 I ns/openshift-marketplace job/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfbff3b Job completed
Mar 05 02:10:58.971 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide requirements not yet checked
Mar 05 02:10:58.971 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide all requirements found, attempting install
Mar 05 02:10:58.971 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide all requirements found, attempting install (2 times)
Mar 05 02:10:59.194 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide waiting for install components to report healthy
Mar 05 02:10:59.198 I ns/openshift-operators deployment/etcd-operator Scaled up replica set etcd-operator-7575d9f47 to 1
Mar 05 02:11:00.425 I ns/openshift-operators replicaset/etcd-operator-7575d9f47 Created pod: etcd-operator-7575d9f47-2svfd
Mar 05 02:11:00.426 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd node/ created
Mar 05 02:11:01.982 I openshift-apiserver OpenShift API started failing: Get "https://api.chuo0305.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 05 02:11:01.982 E kube-apiserver Kube API started failing: Get "https://api.chuo0305.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 05 02:11:02.203 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Successfully assigned openshift-operators/etcd-operator-7575d9f47-2svfd to ip-10-0-73-11.us-east-2.compute.internal
Mar 05 02:11:03.229 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for deployment spec update to be observed...\n
Mar 05 02:11:04.624 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n
Mar 05 02:11:04.624 I ns/openshift-console-operator deployment/console-operator Updated Deployment.apps/downloads -n openshift-console because it changed (16 times)
Mar 05 02:11:04.624 I ns/openshift-console-operator deployment/console-operator Updated Deployment.apps/downloads -n openshift-console because it changed (17 times)
Mar 05 02:11:04.624 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Add eth0 [10.128.2.47/23]
Mar 05 02:11:08.983 E kube-apiserver Kube API is not responding to GET requests
Mar 05 02:11:08.983 E openshift-apiserver OpenShift API is not responding to GET requests
Mar 05 02:11:09.151 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Pulling image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b"
Mar 05 02:11:09.665 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Successfully pulled image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" in 3.107326991s
Mar 05 02:11:09.665 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Created container etcd-operator
Mar 05 02:11:09.892 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Started container etcd-operator
Mar 05 02:11:09.892 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Mar 05 02:11:09.892 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Created container etcd-backup-operator
Mar 05 02:11:10.120 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Started container etcd-backup-operator
Mar 05 02:11:10.120 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Mar 05 02:11:10.461 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Created container etcd-restore-operator
Mar 05 02:11:10.461 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Started container etcd-restore-operator
Mar 05 02:11:11.224 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide install strategy completed with no errors
Mar 05 02:11:11.224 I openshift-apiserver OpenShift API started responding to GET requests
Mar 05 02:11:11.224 I kube-apiserver Kube API started responding to GET requests
Mar 05 02:11:33.426 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Stopping container etcd-restore-operator
Mar 05 02:11:33.426 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Stopping container etcd-backup-operator
Mar 05 02:11:33.426 I ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd Stopping container etcd-operator
Mar 05 02:11:33.426 W ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd node/ip-10-0-73-11.us-east-2.compute.internal graceful deletion within 30s
Mar 05 02:11:34.425 W ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd node/ip-10-0-73-11.us-east-2.compute.internal container=etcd-backup-operator container stopped being ready
Mar 05 02:11:34.425 W ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd node/ip-10-0-73-11.us-east-2.compute.internal container=etcd-operator container stopped being ready
Mar 05 02:11:34.425 W ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd node/ip-10-0-73-11.us-east-2.compute.internal container=etcd-restore-operator container stopped being ready
Mar 05 02:11:37.363 W ns/openshift-operators pod/etcd-operator-7575d9f47-2svfd node/ip-10-0-73-11.us-east-2.compute.internal deleted

1 pass, 0 skip (2m47s)
```