### PR TITLE
update logs

### DIFF
--- a/test/extended/operators/olm_utils.go
+++ b/test/extended/operators/olm_utils.go
@@ -879,6 +879,11 @@ func getResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, parameters
 //the expect is ok, contain or compare result is OK for method == expect, no error raise. if not OK, error raise
 //the expect is nok, contain or compare result is NOK for method == expect, no error raise. if OK, error raise
 func expectedResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, isCompare bool, content string, expect bool, parameters ...string) error {
+	expectMap := map[bool]string{
+		true:  "do",
+		false: "do not",
+	}
+
 	cc := func(a, b string, ic bool) bool {
 		bs := strings.Split(b, "+2+")
 		ret := false
@@ -889,13 +894,14 @@ func expectedResource(oc *exutil.CLI, asAdmin bool, withoutNamespace bool, isCom
 		}
 		return ret
 	}
+	e2e.Logf("Running: oc get asAdmin(%t) withoutNamespace(%t) %s", asAdmin, withoutNamespace, strings.Join(parameters, " "))
 	return wait.Poll(3*time.Second, 150*time.Second, func() (bool, error) {
 		output, err := doAction(oc, "get", asAdmin, withoutNamespace, parameters...)
 		if err != nil {
 			e2e.Logf("the get error is %v, and try next", err)
 			return false, nil
 		}
-		e2e.Logf("the queried resource:%s", output)
+		e2e.Logf("---> we %v expect value: %s, in returned value: %s", expectMap[expect], content, output)
 		if isCompare && expect && cc(output, content, isCompare) {
 			e2e.Logf("the output %s matches one of the content %s, expected", output, content)
 			return true, nil


### PR DESCRIPTION
I updated the log output so that we can locate the step quickly when debugging. 
```console
mac:openshift-tests jianzhang$ ./bin/extended-platform-tests run all --dry-run |grep 23440|./bin/extended-platform-tests run -f -
I0309 15:28:37.053022   92207 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0309 15:28:51.664086   92209 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]"

I0309 15:29:15.191283   92209 trace.go:116] Trace[780548566]: "Reflector ListAndWatch" name:pkg/mod/github.com/openshift/kubernetes-client-go@v0.0.0-20200106170045-1fda2942f64d/tools/cache/reflector.go:105 (started: 2021-03-09 15:28:51.692999 +0800 CST m=+30.328590460) (total time: 23.497765288s):
Trace[780548566]: [23.497715626s] [23.497715626s] Objects listed
I0309 15:29:20.004919   92209 trace.go:116] Trace[1502399443]: "Reflector ListAndWatch" name:pkg/mod/github.com/openshift/kubernetes-client-go@v0.0.0-20200106170045-1fda2942f64d/tools/cache/reflector.go:105 (started: 2021-03-09 15:28:51.693366 +0800 CST m=+30.328957019) (total time: 28.310928986s):
Trace[1502399443]: [28.310825633s] [28.310825633s] Objects listed
E0309 15:29:34.711589   92209 request.go:929] Unexpected error when reading response body: net/http: request canceled (Client.Timeout or context cancellation while reading body)
E0309 15:29:34.711705   92209 request.go:929] Unexpected error when reading response body: net/http: request canceled (Client.Timeout or context cancellation while reading body)
I0309 15:29:51.077653   92209 trace.go:116] Trace[151138994]: "Reflector ListAndWatch" name:pkg/mod/github.com/openshift/kubernetes-client-go@v0.0.0-20200106170045-1fda2942f64d/tools/cache/reflector.go:105 (started: 2021-03-09 15:28:51.692562 +0800 CST m=+30.328153045) (total time: 59.383875791s):
Trace[151138994]: [59.383560813s] [59.383560813s] Objects listed
E0309 15:31:54.288279   92209 request.go:929] Unexpected error when reading response body: context deadline exceeded (Client.Timeout or context cancellation while reading body)
I0309 15:29:16.979258   92216 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Mar  9 15:29:17.022: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Mar  9 15:29:28.760: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Mar  9 15:29:29.638: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Mar  9 15:29:29.638: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Mar  9 15:29:29.638: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Mar  9 15:29:29.944: INFO: e2e test version: v0.0.0-master+$Format:%h$
Mar  9 15:29:30.243: INFO: kube-apiserver version: v1.20.0+77a09d3
Mar  9 15:29:31.277: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:111
Mar  9 15:29:35.316: INFO: configPath is now "/var/folders/2c/4whhm34n7892mf9l2j02cf480000gn/T/configfile367338258"
Mar  9 15:29:35.316: INFO: The user is now "e2e-test-olm-74ww6-user"
Mar  9 15:29:35.316: INFO: Creating project "e2e-test-olm-74ww6"
Mar  9 15:29:36.286: INFO: Waiting on permissions in project "e2e-test-olm-74ww6" ...
Mar  9 15:29:36.539: INFO: Waiting for ServiceAccount "default" to be provisioned...
Mar  9 15:29:36.898: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Mar  9 15:29:37.309: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Mar  9 15:29:38.538: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Mar  9 15:29:39.412: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Mar  9 15:29:40.395: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Mar  9 15:29:41.659: INFO: Project "e2e-test-olm-74ww6" has been fully provisioned.
[It] Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:149
Mar  9 15:29:45.640: INFO: configPath is now "/var/folders/2c/4whhm34n7892mf9l2j02cf480000gn/T/configfile967642441"
Mar  9 15:29:45.640: INFO: The user is now "e2e-test-olm-ndfs2-user"
Mar  9 15:29:45.640: INFO: Creating project "e2e-test-olm-ndfs2"
Mar  9 15:29:46.566: INFO: Waiting on permissions in project "e2e-test-olm-ndfs2" ...
Mar  9 15:29:47.131: INFO: Waiting for ServiceAccount "default" to be provisioned...
Mar  9 15:29:47.868: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Mar  9 15:29:49.085: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Mar  9 15:29:50.291: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Mar  9 15:29:51.355: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Mar  9 15:29:51.953: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Mar  9 15:29:54.512: INFO: Project "e2e-test-olm-ndfs2" has been fully provisioned.
STEP: Cluster-admin start to subscribe to etcd operator
Mar  9 15:29:59.011: INFO: the file of resource is /tmp/e2e-test-olm-ndfs2-flebhe32olm-config.json
E0309 15:30:31.185587   92232 request.go:1001] Unexpected error when reading response body: net/http: request canceled (Client.Timeout or context cancellation while reading body)
subscription.operators.coreos.com/sub-23440 created
Mar  9 15:30:46.642: INFO: Running: oc get asAdmin(true) withoutNamespace(true) sub sub-23440 -n openshift-operators -o=jsonpath={.status.state}
Mar  9 15:30:51.591: INFO: ---> we do expect value: AtLatestKnown, in returned value: UpgradePending
Mar  9 15:30:56.328: INFO: ---> we do expect value: AtLatestKnown, in returned value: UpgradePending
Mar  9 15:31:02.376: INFO: ---> we do expect value: AtLatestKnown, in returned value: AtLatestKnown
Mar  9 15:31:02.376: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
Mar  9 15:31:16.135: INFO: the result of queried resource:etcdoperator.v0.9.4-clusterwide
Mar  9 15:31:16.135: INFO: the installed CSV name is etcdoperator.v0.9.4-clusterwide
Mar  9 15:31:16.135: INFO: Running: oc get asAdmin(true) withoutNamespace(true) csv etcdoperator.v0.9.4-clusterwide -n openshift-operators -o=jsonpath={.status.phase}
Mar  9 15:31:22.644: INFO: ---> we do expect value: Succeeded, in returned value: Succeeded
Mar  9 15:31:22.644: INFO: the output Succeeded matches one of the content Succeeded, expected
STEP: Switch to common user to create the resources provided by the operator
etcdcluster.etcd.database.coreos.com/example-etcd-cluster created
Mar  9 15:31:42.640: INFO: Running: oc get asAdmin(false) withoutNamespace(true) etcdCluster example-etcd-cluster -n e2e-test-olm-ndfs2 -o=jsonpath={.status.phase}
Mar  9 15:31:46.801: INFO: ---> we do expect value: Running, in returned value: Running
Mar  9 15:31:46.801: INFO: the output Running matches one of the content Running, expected
Mar  9 15:31:57.347: INFO: Error running /usr/local/bin/oc --kubeconfig=/Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/kui-kubeconfig get csv etcdoperator.v0.9.4-clusterwide -n openshift-operators:
Error from server (NotFound): clusterserviceversions.operators.coreos.com "etcdoperator.v0.9.4-clusterwide" not found
Mar  9 15:31:57.347: INFO: the resource is delete successfully
Mar  9 15:32:06.673: INFO: Error running /usr/local/bin/oc --kubeconfig=/Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/kui-kubeconfig get sub sub-23440 -n openshift-operators:
Error from server (NotFound): subscriptions.operators.coreos.com "sub-23440" not found
Mar  9 15:32:06.673: INFO: the resource is delete successfully
[AfterEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/src/github.com/openshift/openshift-tests/test/extended/util/client.go:102
Mar  9 15:32:10.183: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-74ww6-user}, err: <nil>
Mar  9 15:32:10.774: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-74ww6}, err: <nil>
Mar  9 15:32:11.320: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  nftS468CSpmqvKRK-D-SDgAAAAAAAAAA}, err: <nil>
Mar  9 15:32:11.627: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-ndfs2-user}, err: <nil>
Mar  9 15:32:13.005: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-ndfs2}, err: <nil>
Mar  9 15:32:13.757: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  i801l79FT1WHlLbTbMMFzQAAAAAAAAAA}, err: <nil>
[AfterEach] [sig-operators] OLM for an end user use
  /Users/jianzhang/goproject/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Mar  9 15:32:13.757: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-74ww6" for this suite.
STEP: Destroying namespace "e2e-test-olm-ndfs2" for this suite.
Mar  9 15:32:22.579: INFO: Running AfterSuite actions on all nodes
Mar  9 15:32:22.579: INFO: Running AfterSuite actions on node 1

passed: (3m31s) 2021-03-09T07:32:22 "[sig-operators] OLM for an end user use Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]"


Timeline:

Mar 09 07:28:55.697 I openshift-apiserver OpenShift API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Mar 09 07:28:55.697 E kube-apiserver Kube API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 09 07:29:06.694 - 30s   E kube-apiserver Kube API is not responding to GET requests
Mar 09 07:29:06.694 - 30s   E openshift-apiserver OpenShift API is not responding to GET requests
Mar 09 07:29:51.032 I openshift-apiserver OpenShift API started responding to GET requests
Mar 09 07:29:51.032 I kube-apiserver Kube API started responding to GET requests
Mar 09 07:29:51.695 - 150s  W ns/openshift-marketplace pod/qe-app-registry-fd7lt node/ip-10-0-146-14.us-east-2.compute.internal pod has been pending longer than a minute
Mar 09 07:29:51.695 - 150s  W ns/openshift-marketplace pod/qe-app-registry-bfs4w node/ip-10-0-160-152.us-east-2.compute.internal pod has been pending longer than a minute
Mar 09 07:30:49.699 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 node/ created
Mar 09 07:30:50.162 I ns/openshift-marketplace job/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfbff3b Created pod: eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7
Mar 09 07:30:50.271 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Successfully assigned openshift-marketplace/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 to ip-10-0-146-14.us-east-2.compute.internal
Mar 09 07:30:54.827 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Add eth0 [10.131.0.165/23]
Mar 09 07:30:55.059 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Container image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:be742fbf17fc934e092db92f33a26a4e93e0dad1b982005319c5239075775259" already present on machine
Mar 09 07:30:55.059 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Created container util
Mar 09 07:30:55.059 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Started container util
Mar 09 07:30:55.059 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Pulling image "quay.io/openshift-community-operators/etcd:v0.9.4-clusterwide"
Mar 09 07:30:56.321 E kube-apiserver Kube API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 09 07:30:56.901 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Successfully pulled image "quay.io/openshift-community-operators/etcd:v0.9.4-clusterwide" in 1.071307043s
Mar 09 07:30:56.901 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Created container pull
Mar 09 07:30:57.182 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Started container pull
Mar 09 07:30:57.182 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Container image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8b68f55ca0cb1fd661a689eea7ef9abb373cd2c95c54046894344b35e540150b" already present on machine
Mar 09 07:30:58.063 I openshift-apiserver OpenShift API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 09 07:30:58.308 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Created container extract
Mar 09 07:30:58.308 I ns/openshift-marketplace pod/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfrvbf7 Started container extract
Mar 09 07:30:58.847 W ns/openshift-marketplace pod/qe-app-registry-fd7lt Error: ImagePullBackOff (1612 times)
Mar 09 07:30:58.847 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide requirements not yet checked
Mar 09 07:30:58.847 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide requirements not yet checked (2 times)
Mar 09 07:30:58.918 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide all requirements found, attempting install
Mar 09 07:31:02.096 I ns/openshift-marketplace job/eff5a04e02ff20331620c17b99eeb682586f23da740269bc78e96d58bfbff3b Job completed
Mar 09 07:31:02.097 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide all requirements found, attempting install (2 times)
Mar 09 07:31:02.334 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide waiting for install components to report healthy
Mar 09 07:31:02.334 I ns/openshift-operators deployment/etcd-operator Scaled up replica set etcd-operator-7575d9f47 to 1
Mar 09 07:31:03.354 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh node/ created
Mar 09 07:31:03.367 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for deployment spec update to be observed...\n
Mar 09 07:31:03.367 I ns/openshift-operators replicaset/etcd-operator-7575d9f47 Created pod: etcd-operator-7575d9f47-stgmh
Mar 09 07:31:03.367 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Successfully assigned openshift-operators/etcd-operator-7575d9f47-stgmh to ip-10-0-146-14.us-east-2.compute.internal
Mar 09 07:31:03.368 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide installing: waiting for deployment etcd-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n
Mar 09 07:31:06.700 E kube-apiserver Kube API is not responding to GET requests
Mar 09 07:31:06.700 E openshift-apiserver OpenShift API is not responding to GET requests
Mar 09 07:31:06.703 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Add eth0 [10.131.0.166/23]
Mar 09 07:31:08.338 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Pulling image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b"
Mar 09 07:31:10.543 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Successfully pulled image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" in 4.17100281s
Mar 09 07:31:10.543 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Created container etcd-operator
Mar 09 07:31:10.543 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Started container etcd-operator
Mar 09 07:31:11.342 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Mar 09 07:31:11.342 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Created container etcd-backup-operator
Mar 09 07:31:11.342 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Started container etcd-backup-operator
Mar 09 07:31:11.358 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Container image "quay.io/coreos/etcd-operator@sha256:66a37fd61a06a43969854ee6d3e21087a98b93838e284a6086b13917f96b0d9b" already present on machine
Mar 09 07:31:11.358 W ns/openshift-marketplace pod/qe-app-registry-bfs4w Error: ImagePullBackOff (1651 times)
Mar 09 07:31:11.358 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Created container etcd-restore-operator
Mar 09 07:31:12.540 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Started container etcd-restore-operator
Mar 09 07:31:12.540 I openshift-apiserver OpenShift API started responding to GET requests
Mar 09 07:31:12.540 W endpoints/etcd-restore-operator Failed to create endpoint for service openshift-operators/etcd-restore-operator: endpoints "etcd-restore-operator" already exists
Mar 09 07:31:12.540 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide install strategy completed with no errors
Mar 09 07:31:12.540 I ns/openshift-operators clusterserviceversion/etcdoperator.v0.9.4-clusterwide install strategy completed with no errors (2 times)
Mar 09 07:31:12.849 I kube-apiserver Kube API started responding to GET requests
Mar 09 07:31:39.646 I ns/openshift-marketplace pod/community-operators-q58nq node/ created
Mar 09 07:31:39.885 I ns/openshift-marketplace pod/community-operators-q58nq Successfully assigned openshift-marketplace/community-operators-q58nq to ip-10-0-146-14.us-east-2.compute.internal
Mar 09 07:31:40.805 I ns/openshift-marketplace pod/community-operators-q58nq Add eth0 [10.131.0.167/23]
Mar 09 07:31:41.111 I ns/openshift-marketplace pod/community-operators-q58nq Pulling image "registry.redhat.io/redhat/community-operator-index:v4.7"
Mar 09 07:31:41.783 I ns/openshift-marketplace pod/community-operators-q58nq Successfully pulled image "registry.redhat.io/redhat/community-operator-index:v4.7" in 1.696000126s
Mar 09 07:31:41.805 I ns/openshift-marketplace pod/community-operators-q58nq Created container registry-server
Mar 09 07:31:42.014 I ns/openshift-marketplace pod/community-operators-q58nq Started container registry-server
Mar 09 07:31:44.702 E kube-apiserver Kube API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 09 07:31:44.702 I openshift-apiserver OpenShift API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 09 07:31:47.489 I kube-apiserver Kube API started responding to GET requests
Mar 09 07:31:47.489 I openshift-apiserver OpenShift API started responding to GET requests
Mar 09 07:31:50.586 I ns/openshift-marketplace pod/community-operators-q58nq Stopping container registry-server
Mar 09 07:31:50.587 W ns/openshift-marketplace pod/community-operators-q58nq node/ip-10-0-146-14.us-east-2.compute.internal graceful deletion within 0s
Mar 09 07:31:51.282 I ns/openshift-marketplace pod/community-operators-q58nq Stopping container registry-server (2 times)
Mar 09 07:31:51.283 W ns/openshift-marketplace pod/community-operators-q58nq node/ip-10-0-146-14.us-east-2.compute.internal deleted
Mar 09 07:31:51.631 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Stopping container etcd-restore-operator
Mar 09 07:31:51.631 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Stopping container etcd-backup-operator
Mar 09 07:31:51.632 W ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh node/ip-10-0-146-14.us-east-2.compute.internal graceful deletion within 30s
Mar 09 07:31:51.745 I ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh Stopping container etcd-operator
Mar 09 07:31:52.888 W ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh node/ip-10-0-146-14.us-east-2.compute.internal container=etcd-backup-operator container stopped being ready
Mar 09 07:31:52.888 W ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh node/ip-10-0-146-14.us-east-2.compute.internal container=etcd-operator container stopped being ready
Mar 09 07:31:52.888 W ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh node/ip-10-0-146-14.us-east-2.compute.internal container=etcd-restore-operator container stopped being ready
Mar 09 07:31:54.288 I openshift-apiserver OpenShift API started failing: unexpected error when reading response body. Please retry. Original error: context deadline exceeded (Client.Timeout or context cancellation while reading body)
Mar 09 07:31:55.890 E kube-apiserver Kube API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 09 07:31:58.593 I kube-apiserver Kube API started responding to GET requests
Mar 09 07:32:00.159 I openshift-apiserver OpenShift API started responding to GET requests
Mar 09 07:32:00.160 W ns/openshift-operators pod/etcd-operator-7575d9f47-stgmh node/ip-10-0-146-14.us-east-2.compute.internal deleted
Mar 09 07:32:03.159 I openshift-apiserver OpenShift API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/apis/image.openshift.io/v1/namespaces/openshift-apiserver/imagestreams/missing?timeout=3s": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Mar 09 07:32:03.391 E kube-apiserver Kube API started failing: Get "https://api.kui030920.qe.devcluster.openshift.com:6443/api/v1/namespaces/kube-system?timeout=3s": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Mar 09 07:32:04.384 I kube-apiserver Kube API started responding to GET requests
Mar 09 07:32:04.384 I openshift-apiserver OpenShift API started responding to GET requests

1 pass, 0 skip (3m31s)
```