### PR TITLE
support new format

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -704,14 +705,9 @@ func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 		c.AddExplicitResourceToDelete(oauthv1.GroupVersion.WithResource("oauthclients"), "", oauthClientName)
 	}
 
-	randomToken := uuid.NewRandom()
-	accesstoken := base64.RawURLEncoding.EncodeToString([]byte(randomToken))
-	// make sure the token is long enough to pass validation
-	for i := len(accesstoken); i < 32; i++ {
-		accesstoken += "A"
-	}
+	privToken, pubToken := GenerateOAuthTokenPair()
 	token, err := oauthClient.OauthV1().OAuthAccessTokens().Create(&oauthv1.OAuthAccessToken{
-		ObjectMeta:  metav1.ObjectMeta{Name: accesstoken},
+		ObjectMeta:  metav1.ObjectMeta{Name: pubToken},
 		ClientName:  oauthClientName,
 		UserName:    username,
 		UserUID:     string(user.UID),
@@ -724,9 +720,20 @@ func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 	c.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthaccesstokens"), token)
 
 	userClientConfig := rest.AnonymousClientConfig(turnOffRateLimiting(rest.CopyConfig(c.AdminConfig())))
-	userClientConfig.BearerToken = token.Name
+	userClientConfig.BearerToken = privToken
 
 	return userClientConfig
+}
+
+// GenerateOAuthTokenPair returns two tokens to use with OpenShift OAuth-based authentication.
+// The first token is a private token meant to be used as a Bearer token to send
+// queries to the API, the second token is a hashed token meant to be stored in
+// the database.
+func GenerateOAuthTokenPair() (privToken, pubToken string) {
+	const sha256Prefix = "sha256~"
+	randomToken := base64.RawURLEncoding.EncodeToString(uuid.NewRandom())
+	hashed := sha256.Sum256([]byte(randomToken))
+	return sha256Prefix + string(randomToken), sha256Prefix + base64.RawURLEncoding.EncodeToString(hashed[:])
 }
 
 // turnOffRateLimiting reduces the chance that a flaky test can be written while using this package


### PR DESCRIPTION
@jianzhangbjz could you please review it? thanks
```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ocro "23440"
rm -f ./bin/extended-platform-tests
ln -s /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/vendor "/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.Tv7swiZJ/src"
export GO111MODULE=off && export GOPATH=/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.Tv7swiZJ && export GOBIN=/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.Tv7swiZJ/bin && go install "./vendor/github.com/jteeuwen/go-bindata/..."
/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.Tv7swiZJ/bin/go-bindata -nocompress -nometadata -prefix "testextended" -pkg "testdata" -o "./test/extended/testdata/bindata.go" -ignore "OWNERS" test/extended/testdata/... examples/... test/integration/testdata/... && gofmt -s -w "./test/extended/testdata/bindata.go"
ln -s /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/vendor "/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.GRZVjl6o/src"
export GO111MODULE=off && export GOPATH=/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.GRZVjl6o && export GOBIN=/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.GRZVjl6o/bin && go install "./vendor/github.com/jteeuwen/go-bindata/..."
/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/tmp.GRZVjl6o/bin/go-bindata -nocompress -nometadata -prefix "testextended" -pkg "testdata" -o "./test/extended/testdata/bindata.go" -ignore "OWNERS" test/extended/testdata/... examples/... test/integration/testdata/... && gofmt -s -w "./test/extended/testdata/bindata.go"
mkdir -p "bin"
go build -o "bin" "./cmd/extended-platform-tests"
I0415 16:34:50.929994   80552 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0415 16:34:51.317750   80554 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[sig-operators] OLM for an end user use Author:jiazha-Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]"

I0415 16:34:58.527307   80559 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Apr 15 16:34:58.561: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Apr 15 16:34:59.421: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Apr 15 16:35:00.341: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Apr 15 16:35:00.341: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Apr 15 16:35:00.341: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Apr 15 16:35:00.568: INFO: e2e test version: v0.0.0-master+$Format:%h$
Apr 15 16:35:00.786: INFO: kube-apiserver version: v1.21.0-rc.0+e22a836
Apr 15 16:35:01.009: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/kuiwang/GoProject/go-origin/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [sig-operators] OLM for an end user use
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/client.go:112
Apr 15 16:35:02.873: INFO: configPath is now "/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/configfile396561361"
Apr 15 16:35:02.873: INFO: The user is now "e2e-test-olm-kf22s-user"
Apr 15 16:35:02.873: INFO: Creating project "e2e-test-olm-kf22s"
Apr 15 16:35:03.245: INFO: Waiting on permissions in project "e2e-test-olm-kf22s" ...
Apr 15 16:35:03.458: INFO: Waiting for ServiceAccount "default" to be provisioned...
Apr 15 16:35:03.775: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Apr 15 16:35:04.096: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Apr 15 16:35:04.416: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Apr 15 16:35:04.843: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Apr 15 16:35:05.270: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Apr 15 16:35:05.694: INFO: Project "e2e-test-olm-kf22s" has been fully provisioned.
[It] Author:jiazha-Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:149
Apr 15 16:35:07.130: INFO: configPath is now "/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/configfile588069628"
Apr 15 16:35:07.130: INFO: The user is now "e2e-test-olm-5gztf-user"
Apr 15 16:35:07.130: INFO: Creating project "e2e-test-olm-5gztf"
Apr 15 16:35:07.470: INFO: Waiting on permissions in project "e2e-test-olm-5gztf" ...
Apr 15 16:35:07.681: INFO: Waiting for ServiceAccount "default" to be provisioned...
Apr 15 16:35:08.001: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Apr 15 16:35:08.322: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Apr 15 16:35:08.645: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Apr 15 16:35:09.076: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Apr 15 16:35:09.502: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Apr 15 16:35:09.929: INFO: Project "e2e-test-olm-5gztf" has been fully provisioned.
STEP: Cluster-admin start to subscribe to etcd operator
Apr 15 16:35:14.005: INFO: the file of resource is /tmp/e2e-test-olm-5gztf-d2tw2sk9olm-config.json
subscription.operators.coreos.com/sub-23440 created
STEP: try to get installPlan and CSV of the sub
Apr 15 16:35:31.431: INFO: the result of queried resource:install-q4qkn
Apr 15 16:35:35.428: INFO: the result of queried resource:sub-23440
Apr 15 16:35:35.428: INFO: found installplan and try to get csv
Apr 15 16:35:39.502: INFO: the result of queried resource:etcdoperator.v0.9.4-clusterwide
Apr 15 16:35:39.502: INFO: Running: oc get asAdmin(true) withoutNamespace(true) csv etcdoperator.v0.9.4-clusterwide -n openshift-operators -o=jsonpath={.status.phase}
Apr 15 16:35:43.719: INFO: ---> we do expect value: Succeeded, in returned value: Succeeded
Apr 15 16:35:43.719: INFO: the output Succeeded matches one of the content Succeeded, expected
STEP: Switch to common user to create the resources provided by the operator
etcdcluster.etcd.database.coreos.com/example-etcd-cluster created
Apr 15 16:35:50.522: INFO: Running: oc get asAdmin(false) withoutNamespace(true) etcdCluster example-etcd-cluster -n e2e-test-olm-5gztf -o=jsonpath={.status.phase}
Apr 15 16:35:54.418: INFO: ---> we do expect value: Running, in returned value: Running
Apr 15 16:35:54.418: INFO: the output Running matches one of the content Running, expected
Apr 15 16:36:00.830: INFO: Error running /Users/kuiwang/work/bin/oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get csv etcdoperator.v0.9.4-clusterwide -n openshift-operators:
Error from server (NotFound): clusterserviceversions.operators.coreos.com "etcdoperator.v0.9.4-clusterwide" not found
Apr 15 16:36:00.830: INFO: the resource is delete successfully
Apr 15 16:36:05.879: INFO: Error running /Users/kuiwang/work/bin/oc --kubeconfig=/Users/kuiwang/work/bin/jb/kubeconf/kubeconfig get sub sub-23440 -n openshift-operators:
Error from server (NotFound): subscriptions.operators.coreos.com "sub-23440" not found
Apr 15 16:36:05.879: INFO: the resource is delete successfully
[AfterEach] [sig-operators] OLM for an end user use
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/client.go:103
Apr 15 16:36:06.135: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-kf22s-user}, err: <nil>
Apr 15 16:36:06.385: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-kf22s}, err: <nil>
Apr 15 16:36:06.625: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~GITksgekQHvn-d9XEs_oEnQekf0ypA6QVC_8WN1f2yM}, err: <nil>
Apr 15 16:36:06.868: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-5gztf-user}, err: <nil>
Apr 15 16:36:07.119: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-5gztf}, err: <nil>
Apr 15 16:36:07.365: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~yrl6AgEbN43THeMjc5C9HnmzPfCgsEBhtmPQiz9LmKc}, err: <nil>
[AfterEach] [sig-operators] OLM for an end user use
  /Users/kuiwang/GoProject/go-origin/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Apr 15 16:36:07.365: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-kf22s" for this suite.
STEP: Destroying namespace "e2e-test-olm-5gztf" for this suite.
Apr 15 16:36:08.580: INFO: Running AfterSuite actions on all nodes
Apr 15 16:36:08.580: INFO: Running AfterSuite actions on node 1

passed: (1m17s) 2021-04-15T08:36:08 "[sig-operators] OLM for an end user use Author:jiazha-Critical-23440-can subscribe to the etcd operator  [Serial] [Suite:openshift/conformance/serial]"
```