### PR TITLE
prepare for long duration to add new label Exclusive

### DIFF
--- a/test/extended/util/test.go
+++ b/test/extended/util/test.go
@@ -466,6 +466,7 @@ var (
 		// tests that must be run without competition
 		"[Serial]": {
 			`\[Disruptive\]`,
+			`\[Exclusive\]`,
 			`\[Feature:Performance\]`,            // requires isolation
 			`\[Feature:ManualPerformance\]`,      // requires isolation
 			`\[Feature:HighDensityPerformance\]`, // requires no other namespaces
@@ -563,6 +564,7 @@ var (
 	excludedTests = []string{
 		`\[Disabled:`,
 		`\[Disruptive\]`,
+		`\[Exclusive\]`,
 		`\[Skipped\]`,
 		`\[Slow\]`,
 		`\[Flaky\]`,


### PR DESCRIPTION
@jianzhangbjz prepare for long duration to add new label Exclusive to mean when the case is executed,  this case requires only this one being executed in the cluster.

```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run|grep Exclusive
I0513 15:38:34.017179   48907 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
"[sig-operators] OLM for an end user handle within all namespace ConnectedOnly-Author:kuiwang-High-25783-Subscriptions are not getting processed taking very long to get processed [Exclusive] [Serial]"
```