### PR TITLE
update 25855

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -322,7 +322,7 @@ var _ = g.Describe("[sig-operators] OLM for an end user handle within a namespac
 
 		g.By("check the subscription_sync_total")
 		err := wait.Poll(10*time.Second, 120*time.Second, func() (bool, error) {
-			subscriptionSyncTotal, _ := exec.Command("bash", "-c", "oc exec -c catalog-operator "+infoCatalogOperator[0]+" -n openshift-operator-lifecycle-manager -- curl -s -k -H 'Authorization: Bearer $(oc sa get-token prometheus-k8s -n openshift-monitoring)' https://"+infoCatalogOperator[1]+"/metrics").Output()
+			subscriptionSyncTotal, _ := exec.Command("bash", "-c", "oc exec -c catalog-operator "+infoCatalogOperator[0]+" -n openshift-operator-lifecycle-manager -- curl -s -k -H 'Authorization: Bearer $(oc create token prometheus-k8s -n openshift-monitoring)' https://"+infoCatalogOperator[1]+"/metrics").Output()
 			if !strings.Contains(string(subscriptionSyncTotal), sub.installedCSV) {
 				e2e.Logf("the metric is not counted and try next round")
 				return false, nil


### PR DESCRIPTION
```console
kuiwang@Kuis-MacBook-Pro openshift-tests % ./bin/extended-platform-tests run all --dry-run|grep 25855|./bin/extended-platform-tests run -f -
I0808 11:03:00.835321   39242 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
I0808 11:03:01.226422   39244 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
started: (0/1/1) "[sig-operators] OLM for an end user handle within a namespace ConnectedOnly-Author:kuiwang-High-25855-Add the channel field to subscription_sync_count [Suite:openshift/conformance/parallel]"

I0808 11:03:09.119898   39247 test_context.go:419] Tolerating taints "node-role.kubernetes.io/master" when considering if nodes are ready
Aug  8 11:03:09.153: INFO: Waiting up to 30m0s for all (but 100) nodes to be schedulable
Aug  8 11:03:09.831: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Aug  8 11:03:10.498: INFO: 0 / 0 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Aug  8 11:03:10.498: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Aug  8 11:03:10.498: INFO: Waiting up to 5m0s for all daemonsets in namespace 'kube-system' to start
Aug  8 11:03:10.724: INFO: e2e test version: v0.0.0-master+$Format:%h$
Aug  8 11:03:10.950: INFO: kube-apiserver version: v1.24.0+a9d6306
Aug  8 11:03:11.177: INFO: Cluster IP family: ipv4
[BeforeEach] [Top Level]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/test.go:60
[BeforeEach] [sig-operators] OLM for an end user handle within a namespace
  /Users/kuiwang/GoProject/go-origin/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:154
STEP: Creating a kubernetes client
[BeforeEach] [sig-operators] OLM for an end user handle within a namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/client.go:112
Aug  8 11:03:13.039: INFO: configPath is now "/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/configfile1243935432"
Aug  8 11:03:13.039: INFO: The user is now "e2e-test-olm-a-jxamxxv4-vtkng-user"
Aug  8 11:03:13.039: INFO: Creating project "e2e-test-olm-a-jxamxxv4-vtkng"
Aug  8 11:03:13.383: INFO: Waiting on permissions in project "e2e-test-olm-a-jxamxxv4-vtkng" ...
Aug  8 11:03:13.612: INFO: Waiting for ServiceAccount "default" to be provisioned...
Aug  8 11:03:13.943: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Aug  8 11:03:14.276: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Aug  8 11:03:14.607: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Aug  8 11:03:15.060: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Aug  8 11:03:15.511: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Aug  8 11:03:15.957: INFO: Project "e2e-test-olm-a-jxamxxv4-vtkng" has been fully provisioned.
[BeforeEach] [sig-operators] OLM for an end user handle within a namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:228
[It] ConnectedOnly-Author:kuiwang-High-25855-Add the channel field to subscription_sync_count [Suite:openshift/conformance/parallel]
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:280
Aug  8 11:03:17.320: INFO: configPath is now "/var/folders/lx/gtd5q85x6vjbswptk517fxch0000gn/T/configfile1058386955"
Aug  8 11:03:17.320: INFO: The user is now "e2e-test-olm-a-jxamxxv4-vfzd6-user"
Aug  8 11:03:17.320: INFO: Creating project "e2e-test-olm-a-jxamxxv4-vfzd6"
Aug  8 11:03:17.649: INFO: Waiting on permissions in project "e2e-test-olm-a-jxamxxv4-vfzd6" ...
Aug  8 11:03:17.875: INFO: Waiting for ServiceAccount "default" to be provisioned...
Aug  8 11:03:18.204: INFO: Waiting for ServiceAccount "deployer" to be provisioned...
Aug  8 11:03:18.530: INFO: Waiting for ServiceAccount "builder" to be provisioned...
Aug  8 11:03:18.860: INFO: Waiting for RoleBinding "system:image-pullers" to be provisioned...
Aug  8 11:03:19.311: INFO: Waiting for RoleBinding "system:image-builders" to be provisioned...
Aug  8 11:03:19.758: INFO: Waiting for RoleBinding "system:deployers" to be provisioned...
Aug  8 11:03:20.210: INFO: Project "e2e-test-olm-a-jxamxxv4-vfzd6" has been fully provisioned.
STEP: Create og
Aug  8 11:03:24.297: INFO: the file of resource is /tmp/e2e-test-olm-a-jxamxxv4-vfzd6-r8h6o48golm-config.json
operatorgroup.operators.coreos.com/og-singlenamespace created
STEP: Create operator
Aug  8 11:03:29.902: INFO: the file of resource is /tmp/e2e-test-olm-a-jxamxxv4-vfzd6-2o5ku3pyolm-config.json
subscription.operators.coreos.com/mta-operator created
Aug  8 11:03:31.621: INFO: Running: oc get asAdmin(true) withoutNamespace(true) sub mta-operator -n e2e-test-olm-a-jxamxxv4-vfzd6 -o=jsonpath={.status.state}
Aug  8 11:03:35.403: INFO: ---> we do expect value: AtLatestKnown, in returned value: UpgradePending
Aug  8 11:03:38.376: INFO: ---> we do expect value: AtLatestKnown, in returned value: AtLatestKnown
Aug  8 11:03:38.377: INFO: the output AtLatestKnown matches one of the content AtLatestKnown, expected
Aug  8 11:03:42.191: INFO: the result of queried resource:windup-operator.0.0.10
Aug  8 11:03:42.191: INFO: the installed CSV name is windup-operator.0.0.10
Aug  8 11:03:42.191: INFO: Running: oc get asAdmin(false) withoutNamespace(false) csv windup-operator.0.0.10 -o=jsonpath={.status.phase}
Aug  8 11:03:46.581: INFO: ---> we do expect value: Succeeded, in returned value: Succeeded
Aug  8 11:03:46.582: INFO: the output Succeeded matches one of the content Succeeded, expected
STEP: get information of catalog operator pod
Aug  8 11:03:50.545: INFO: the result of queried resource:catalog-operator-7d894977bd-464fk 10.129.0.24:8443
STEP: check the subscription_sync_total
[AfterEach] [sig-operators] OLM for an end user handle within a namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/util/client.go:103
Aug  8 11:04:03.426: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-a-jxamxxv4-vtkng-user}, err: <nil>
Aug  8 11:04:03.648: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-a-jxamxxv4-vtkng}, err: <nil>
Aug  8 11:04:03.868: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~asqLcU5r3xLOaXsUIdvS0p9BFLl1pLyM5LD38_QYKxI}, err: <nil>
Aug  8 11:04:04.087: INFO: Deleted {user.openshift.io/v1, Resource=users  e2e-test-olm-a-jxamxxv4-vfzd6-user}, err: <nil>
Aug  8 11:04:04.307: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-olm-a-jxamxxv4-vfzd6}, err: <nil>
Aug  8 11:04:04.526: INFO: Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~Sdwkp2IsAKywgZTVcGsP0e0CXDf-Qrqpf5_Sy70ny38}, err: <nil>
[AfterEach] [sig-operators] OLM for an end user handle within a namespace
  /Users/kuiwang/GoProject/go-origin/pkg/mod/github.com/openshift/kubernetes@v1.17.0-alpha.0.0.20200120180958-5945c3b07163/test/e2e/framework/framework.go:155
Aug  8 11:04:04.526: INFO: Waiting up to 7m0s for all (but 100) nodes to be ready
STEP: Destroying namespace "e2e-test-olm-a-jxamxxv4-vtkng" for this suite.
STEP: Destroying namespace "e2e-test-olm-a-jxamxxv4-vfzd6" for this suite.
[AfterEach] [sig-operators] OLM for an end user handle within a namespace
  /Users/kuiwang/GoProject/go-origin/src/github.com/openshift/openshift-tests/test/extended/operators/olm.go:233
Aug  8 11:04:05.785: INFO: Running AfterSuite actions on all nodes
Aug  8 11:04:05.785: INFO: Running AfterSuite actions on node 1

passed: (1m5s) 2022-08-08T03:04:05 "[sig-operators] OLM for an end user handle within a namespace ConnectedOnly-Author:kuiwang-High-25855-Add the channel field to subscription_sync_count [Suite:openshift/conformance/parallel]"

```

/cc @KeenonLee 