### PR TITLE
change 24829 to Serial

### DIFF
--- a/test/extended/operators/olm.go
+++ b/test/extended/operators/olm.go
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-operators] OLM should", func() {
 	})
 
 	// author: bandrade@redhat.com
-	g.It("Author:bandrade-High-24829-Report Upgradeable in OLM ClusterOperators status", func() {
+	g.It("Author:bandrade-High-24829-Report Upgradeable in OLM ClusterOperators status [Serial]", func() {
 		olmCOs := []string{"operator-lifecycle-manager", "operator-lifecycle-manager-catalog", "operator-lifecycle-manager-packageserver"}
 		for _, co := range olmCOs {
 			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("co", co, "-o=jsonpath={range .status.conditions[*]}{.type}{' '}{.status}").Output()


### PR DESCRIPTION
Some cases will installed Incompatible Operators, make clusteroperator operator-lifecycle-manager Upgradeable status is false, it will impact ocp-24829. Change 24829 to Serial
for example:
https://reportportal-openshift.apps.ocp-c1.prod.psi.redhat.com/ui/#prow/launches/396/202744/11781757/11782418/log?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.type%3DSTEP%26filter.in.status%3DFAILED%252CINTERRUPTED

```
Progressing FalseAvailable TrueDegraded FalseUpgradeable False {"conditions":[{"lastTransitionTime":"2022-08-19T00:18:24Z","message":"Deployed 0.19.0","status":"False","type":"Progressing"},{"lastTransitionTime":"2022-08-19T00:18:24Z","status":"True","type":"Available"},{"lastTransitionTime":"2022-08-19T00:18:24Z","status":"False","type":"Degraded"},{"lastTransitionTime":"2022-08-19T02:01:22Z","message":"ClusterServiceVersions blocking cluster upgrade: **e2e-test-default-fixva449-zs4gr/etcdoperator.v0.9.4** is incompatible with OpenShift minor versions greater than 4.9","reason":"IncompatibleOperatorsInstalled","status":"False","type":"Upgradeable"}],"extension":null,"relatedObjects":[{"group":"operators.coreos.com","name":"packageserver","namespace":"openshift-operator-lifecycle-manager","resource":"clusterserviceversions"}],"versions":[{"name":"operator","version":"4.12.0-0.nightly-2022-08-15-150248"},{"name":"operator-lifecycle-manager","version":"0.19.0"}]}
```
